### PR TITLE
Adaptable tau spacing in ComplexSequences and optimized spacing for standard case

### DIFF
--- a/qupyt/hardware/signal_sources.py
+++ b/qupyt/hardware/signal_sources.py
@@ -535,6 +535,7 @@ class WindFreakOfficial(SignalSource):
         logging.info("WindFreak instance closed".ljust(65, ".") + "[done]")
 
 
+
 class WindFreakSHDMini(SignalSource):
 
     def __init__(self, address: str, configuration: Dict[str, Any]) -> None:
@@ -550,6 +551,8 @@ class WindFreakSHDMini(SignalSource):
     @loop_inputs
     def set_amplitude(self, ampl: ParameterInput) -> None:
         channel, ampl = ampl
+        channel = int(channel)
+        ampl = float(ampl)
         self.instance.write(f"W{ampl}".encode()) # min -13.000, max 20.000
         logging.info("Windfreak set amplitude to".ljust(65, ".") + f"{ampl}")
 
@@ -558,6 +561,8 @@ class WindFreakSHDMini(SignalSource):
     @loop_inputs
     def set_frequency(self, freq: ParameterInput) -> None:
         channel, freq = freq
+        channel = int(channel)
+        freq = float(freq)
         freq = freq / 1.0e6  # convert to MHz
         self.instance.write(f"f{round(freq, 8)}".encode())
         logging.info("Windfreak set frequency to [MHz]".ljust(65, ".") + f"{freq}")
@@ -591,3 +596,4 @@ class WindFreakSHDMini(SignalSource):
     def close(self) -> None:
         self.instance.close()
         logging.info("WindFreak SynthHD Mini instance closed".ljust(65, ".") + "[done]")
+

--- a/qupyt/pulse_sequences/SequenceDesigner.py
+++ b/qupyt/pulse_sequences/SequenceDesigner.py
@@ -48,8 +48,8 @@ class PulseSequenceYaml:
             return False
 
     def translate_yaml_to_numeric_instructions(self) -> None:
-        #if self._sequence_didnt_change():
-        #    return
+        if self._sequence_didnt_change():
+            return
         with open(self.yaml_file, "r", encoding="utf-8") as file:
             sequence_instructions = yaml.safe_load(file)
         sequence_order = sequence_instructions["sequencing_order"]

--- a/qupyt/pulse_sequences/SequenceDesigner.py
+++ b/qupyt/pulse_sequences/SequenceDesigner.py
@@ -48,8 +48,8 @@ class PulseSequenceYaml:
             return False
 
     def translate_yaml_to_numeric_instructions(self) -> None:
-        if self._sequence_didnt_change():
-            return
+        #if self._sequence_didnt_change():
+        #    return
         with open(self.yaml_file, "r", encoding="utf-8") as file:
             sequence_instructions = yaml.safe_load(file)
         sequence_order = sequence_instructions["sequencing_order"]

--- a/qupyt/pulse_sequences/yaml_sequence.py
+++ b/qupyt/pulse_sequences/yaml_sequence.py
@@ -96,16 +96,16 @@ class ComplexSequence:
         taushift: int = 2,
         hard_delay: float = 0,
     ) -> None:
+        self.tau_counter += taushift
         self.sequence.add_pulse(
             channel,
-            start + (self.tau_counter + taushift) * self.tau + hard_delay,
+            start + self.tau_counter * self.tau + hard_delay,
             duration,
             amplitude=self.amplitude,
             frequency=self.mixing_freq,
             phase=phase + self.global_phase,
             sequence_blocks=self.blocks,
         )
-        self.tau_counter += taushift
 
     def gen_phases(
         self,
@@ -149,7 +149,6 @@ class ComplexSequence:
             self.pi_half_pulse_dur,
             self.phases[0],
             taushift=0,
-            hard_delay=0
         )
         for i, phase in enumerate(self.phases[1:-1]):
             if i == 0:

--- a/qupyt/pulse_sequences/yaml_sequence.py
+++ b/qupyt/pulse_sequences/yaml_sequence.py
@@ -135,7 +135,7 @@ class ComplexSequence:
             self.phases = initial_phase + xy8_phases * n + final_phase
             return None
 
-    def write_sequence(self, start: float = 0) -> None:
+    def write_sequence(self, start: float = 0, ts_start: int = 1, ts_end: int = 1) -> None:
         """Iterates over phases attibute and appends
         pulses to sequece instance.
         """
@@ -144,18 +144,18 @@ class ComplexSequence:
             start,
             self.pi_half_pulse_dur,
             self.phases[0],
-            hard_delay=self.pi_half_pulse_dur,
-            taushift=0,
+            taushift=0,  # Apply ts to first pi/2 pulse,
+            hard_delay=0
         )
         for i, phase in enumerate(self.phases[1:-1]):
             if i == 0:
                 self.append_pulse(
-                    self.channel, start, self.pi_pulse_dur, phase, taushift=1
+                    self.channel, start, self.pi_pulse_dur, phase, taushift=ts_start
                 )
             else:
                 self.append_pulse(self.channel, start, self.pi_pulse_dur, phase)
         self.append_pulse(
-            self.channel, start, self.pi_half_pulse_dur, self.phases[-1], taushift=1
+            self.channel, start, self.pi_half_pulse_dur, self.phases[-1], taushift=ts_end, hard_delay = self.pi_half_pulse_dur
         )
 
 

--- a/qupyt/pulse_sequences/yaml_sequence.py
+++ b/qupyt/pulse_sequences/yaml_sequence.py
@@ -148,7 +148,7 @@ class ComplexSequence:
             start,
             self.pi_half_pulse_dur,
             self.phases[0],
-            taushift=0,  # Apply ts to first pi/2 pulse,
+            taushift=0,
             hard_delay=0
         )
         for i, phase in enumerate(self.phases[1:-1]):

--- a/qupyt/pulse_sequences/yaml_sequence.py
+++ b/qupyt/pulse_sequences/yaml_sequence.py
@@ -70,6 +70,8 @@ class ComplexSequence:
         mixing_freq: float = 0,
         blocks: list[str] = ["block_0"],
         global_phase: float = 0,
+        ts_start: float = 1,
+        ts_end: float = 1
     ) -> None:
         self.sequence = sequence_instance
         self.channel: str = channel
@@ -82,6 +84,8 @@ class ComplexSequence:
         self.global_phase: float = global_phase
         self.tau_counter: int = 0
         self.phases: list[float] = []
+        self.ts_start: float = ts_start
+        self.ts_end: float = ts_end
 
     def append_pulse(
         self,
@@ -135,7 +139,7 @@ class ComplexSequence:
             self.phases = initial_phase + xy8_phases * n + final_phase
             return None
 
-    def write_sequence(self, start: float = 0, ts_start: int = 1, ts_end: int = 1) -> None:
+    def write_sequence(self, start: float = 0) -> None:
         """Iterates over phases attibute and appends
         pulses to sequece instance.
         """
@@ -150,12 +154,12 @@ class ComplexSequence:
         for i, phase in enumerate(self.phases[1:-1]):
             if i == 0:
                 self.append_pulse(
-                    self.channel, start, self.pi_pulse_dur, phase, taushift=ts_start
+                    self.channel, start, self.pi_pulse_dur, phase, taushift=self.ts_start
                 )
             else:
                 self.append_pulse(self.channel, start, self.pi_pulse_dur, phase)
         self.append_pulse(
-            self.channel, start, self.pi_half_pulse_dur, self.phases[-1], taushift=ts_end, hard_delay = self.pi_half_pulse_dur
+            self.channel, start, self.pi_half_pulse_dur, self.phases[-1], taushift=self.ts_end, hard_delay = self.pi_half_pulse_dur
         )
 
 


### PR DESCRIPTION
Currently it is was not possible to adjust the spacing between the beginning pi/2 and the following pi pulse as well as the last pi pulse and ending pi/2 pulse in Complex Sequence. Additionally the spacing for the default taushift = 1 was inconsistent as it is tau-pi but should be tau-pi/2 as the spacing between two pi pulses is 2tau - pi. This is now fixed with this code.
As a tau spacing (ts) of 1 is the standard case, this value is set in case it is not further specified, allowing compatibility with all current pulsesequences using ComplexSequence