### PR TITLE
Add auto versioning 

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,10 +1,11 @@
 [build-system]
-requires = ["setuptools"]
+requires = ["setuptools", "setuptools_scm"]
 build-backend = "setuptools.build_meta"
 
 [project]
 name = 'qupyt'
-version = '0.1.0'
+#version = '0.1.0'
+dynamic = ["version"]
 description = 'Provide a framework for quantum sensing experiments'
 license = {text = 'No license of for commercial or non-commercial use is granted'}
 dependencies = [
@@ -31,6 +32,9 @@ dependencies = [
 
 [tool.setuptools.packages]
 find = {}
+
+[tool.setuptools_scm]
+write_to = "qupyt/_version.py"
 
 [project.scripts]
 qupyt = "qupyt.main:main"

--- a/qupyt/measurement_logic/run_measurement.py
+++ b/qupyt/measurement_logic/run_measurement.py
@@ -15,6 +15,7 @@ from qupyt.hardware.device_handler import DeviceHandler, DynamicDeviceHandler
 from qupyt.measurement_logic.data_handling import Data
 from qupyt.hardware.synchronisers import Synchroniser
 from qupyt.hardware.sensors import Sensor
+from qupyt._version import __version__ as qupyt_version
 
 
 def run_measurement(
@@ -60,6 +61,7 @@ def run_measurement(
         print("sensor closed")
         params["filename"] = params["experiment_type"] + "_" + mid
         params["measurement_status"] = return_status
+        params["qupyt_version"] = qupyt_version
 
         data_container.save(params["filename"])
         with open(params["filename"] + ".yaml", "w", encoding="utf-8") as file:


### PR DESCRIPTION
# Added Automatic Version Tracking to Measurement Data

## Summary

PR introduces automatic version tracking for measurement data in QuPyt using setuptools_scm #19. This ensures that each dataset is linked to the version of the code that generated it, improving reproducibility and documentation. If users have uncommitted changes in their code, the version tag will reflect this. However, there is of course no way to track this uncommitted code.

## Implementation details | Version generation

We use `setuptools_scm` to automatically generate version information during build.

For this we use the default configuration of `setuptools_scm`. Relevant parts of `pyproject.toml`:

    [build-system]
    requires = ["setuptools", "setuptools_scm"]

    [project]
    dynamic = ["version"]

    [tool.setuptools_scm]
    write_to = "qupyt/_version.py"

In this configuration, `setuptools_scm` uses the last **version tag** as a base, and increments it PATCH by +1 (X.Y.Z+1), if it detects changes from the tagged commit. In such cases, it further adds the shortened version of the git commit tag to the version number. Finally, if there are any uncommitted changes in the code at build time, the current date will be appended to the version, to indicate a "dirty" build that contains non-committed code and is thus in a non-reproducible state.

Apart from the name of the wheel, this version info gets written to a file in `qupyt/_version` and is this generally accessible within QuPyt.

## Implementation details | Adding version info to data

Previously, there was no way to know what code was used to acquire any given dataset. In this PR, we added code, to add the `__version__` info generated above to the output YAML file before saving to disk. 

## Example of Versioning Behavior

| Git State | Generated Version |
| --- | --- |
| Tagged commit (v1.2.3) | 1.2.3 |
| Commit after v1.2.3 | 1.2.4.dev0+g\<commit-hash\> | 
| Uncommitted Changes | 1.2.4.dev0+g\<commit-hash\>.d\<date\> |