### PR TITLE
Fixed data dimensions for image ROI values resulting from compressed …

### DIFF
--- a/qupyt/hardware/sensors.py
+++ b/qupyt/hardware/sensors.py
@@ -1163,6 +1163,10 @@ class MockCam(Sensor):
         return f"MockCam sensor instance: DAQ(configuration: {self.initial_configuration_dict})"
 
     def _set_roi(self, roi_shape_and_offset: List[int]) -> None:
+        """
+        This function emulates the current behaviour of the GenICam and Basler camera sensor.
+        ROI values are extracted from combined input of the ROI and offset values.
+        """
         self.roi_shape = roi_shape_and_offset[:2]
         _ = roi_shape_and_offset[2:]
 
@@ -1184,7 +1188,7 @@ class MockCam(Sensor):
             synchroniser.trigger()
         noise = np.random.poisson(
             15_000,
-            size=(self.number_measurements, self.roi_shape[0], self.roi_shape[1]),
+            size=(self.number_measurements, *self.roi_shape),
         )
         return noise
 

--- a/qupyt/measurement_logic/data_handling.py
+++ b/qupyt/measurement_logic/data_handling.py
@@ -14,7 +14,6 @@ class Data(ConfigurationMixin):
         self.number_dynamic_steps: int
         self.number_measurements: int
         self.data_type: type
-        self.compress: bool = False
         self.live_compression: bool = False
         self.save_in_chunks: int = 0
         self.reference_channels: int = 2
@@ -38,7 +37,8 @@ class Data(ConfigurationMixin):
         self.reference_channels = int(reference_channels)
 
     def _set_compress_mode(self, compression_value: bool) -> None:
-        self.compress = compression_value
+        logging.warning("Depracation warning! The paremter 'compress' is beeing deprecated.\nPlase use 'live_compression' instead")
+        self.live_compression = compression_value
 
     def _set_live_compression(self, live_compression: bool) -> None:
         self.live_compression = live_compression
@@ -47,6 +47,9 @@ class Data(ConfigurationMixin):
         self.data_type = sensor.target_data_type
 
     def _set_number_dynamic_steps(self, number_dynamic_steps: int) -> None:
+        if number_dynamic_steps < 1:
+            raise ValueError("""Cannot have fewer than 1 dynamic steps. This will result in an empty measurement.
+            If you measure just one step, this is still ONE dynamic step. The first of one.""")
         self.number_dynamic_steps = int(number_dynamic_steps)
 
     def _set_averaging_mode(self, averaging_mode: str) -> None:
@@ -84,10 +87,14 @@ class Data(ConfigurationMixin):
                 *self.roi_shape,
             ]
         elif self.averaging_mode == "spread":
+            measurements_per_channel = self.number_measurements / self.reference_channels
+            if measurements_per_channel != int(measurements_per_channel):
+                raise ValueError(f"""Your number of measurements {self.number_measurements} is not divisible by the number of channels {self.reference_channels}.
+                Please make sure the number of measurements you want to recored can be distributed accross the reference channels. (I.e. number_measurements is divisible by reference_cannels""")
             data_array_dim = [
                 self.reference_channels,
                 self.number_dynamic_steps,
-                int(self.number_measurements / self.reference_channels),
+                int(measurements_per_channel),
                 *self.roi_shape,
             ]
         else:
@@ -127,13 +134,15 @@ class Data(ConfigurationMixin):
     def _update_data_compressed(self, data: np.ndarray, dynamic_step: int) -> None:
         if self.averaging_mode == "sum":
             for i in range(self.reference_channels):
+                ndim = data.ndim
                 self.data[i, dynamic_step] += (
-                    data[i :: self.reference_channels].mean(axis=(1, 2)).sum(axis=0)
+                    data[i :: self.reference_channels].mean(axis=tuple(range(1, ndim))).sum(axis=0)
                 )
         elif self.averaging_mode == "spread":
             for i in range(self.reference_channels):
+                ndim = data.ndim
                 self.data[i, dynamic_step] += (
-                    data[i :: self.reference_channels].mean(axis=(1, 2)).reshape(-1, 1)
+                    data[i :: self.reference_channels].mean(axis=tuple(range(1, ndim))).reshape(-1, 1)
                 )
 
     def save(self, filename: str) -> None:
@@ -144,7 +153,4 @@ class Data(ConfigurationMixin):
          main measurement loop.
         :type filename: str
         """
-        if self.compress:
-            np.save(filename, self.data.mean(axis=(3, 4)))
-        else:
-            np.save(filename, self.data)
+        np.save(filename, self.data)

--- a/tests/measurement_logic/test_data_handling.py
+++ b/tests/measurement_logic/test_data_handling.py
@@ -1,0 +1,85 @@
+from qupyt.hardware.sensors import SensorFactory
+from qupyt.measurement_logic.data_handling import Data
+import pytest
+
+
+# Tests if the number_measurements can be distributed accross the reference channels.
+# Should pass if number_measurements is divisible by reference_channels.
+@pytest.mark.parametrize("reference_channels", [1, 2, 10])  # nframes = 10 should be divisible.
+def test_set_dims_from_sensor(reference_channels):
+    dynamic_steps = 6
+    nframes = 10
+    roi = [10, 10]
+    cam = SensorFactory.create_sensor("MockCam", {"number_measurements": nframes, "image_roi": roi})
+    data = Data({"averaging_mode":"spread",
+                 "dynamic_steps": dynamic_steps,
+                 "live_compression": False,
+                 "reference_channels": reference_channels})
+    data.set_dims_from_sensor(cam)
+    data.create_array()
+    assert data.data.shape == (reference_channels, dynamic_steps, int(nframes/reference_channels), *roi)
+
+
+# Tests if the number_measurements can be distributed accross the reference channels.
+# Expected to raise ValueError becuase number_measurements not divisible by reference_channels.
+@pytest.mark.parametrize("reference_channels", [3, 4])
+def test_set_dims_from_sensor_refuse_dist_measurements_channels(reference_channels):
+    dynamic_steps = 6
+    nframes = 10
+    roi = [10, 10]
+    cam = SensorFactory.create_sensor("MockCam", {"number_measurements": nframes, "image_roi": roi})
+    data = Data({"averaging_mode": "spread",
+                 "dynamic_steps": dynamic_steps,
+                 "live_compression": False,
+                 "reference_channels": reference_channels})
+    data.set_dims_from_sensor(cam)
+    with pytest.raises(ValueError):
+        data.create_array()
+
+
+# Tests the correct Data container creation for
+# various combinations of ROIs / sensor dimensions.
+@pytest.mark.parametrize("reference_channels", [1, 2])
+@pytest.mark.parametrize("image_roi", [[10, 10], [1], [13], [2, 10, 3, 2]])
+def test_set_dims_from_sensor_various_rois(reference_channels, image_roi):
+    dynamic_steps = 6
+    nframes = 10
+    cam = SensorFactory.create_sensor("MockCam", {"number_measurements": nframes, "image_roi": image_roi})
+    # Bypass the roi parsing mechanism of the Mock Sensor to test the behaviour of the Data cotainer. 
+    cam.roi_shape = image_roi
+    data = Data({"averaging_mode": "spread",
+                 "dynamic_steps": dynamic_steps,
+                 "live_compression": False,
+                 "reference_channels": reference_channels})
+    data.set_dims_from_sensor(cam)
+    data.create_array()
+    assert data.data.shape == (reference_channels, dynamic_steps, int(nframes/reference_channels), *image_roi)
+    data.update_data(cam.acquire_data(), 0, 0)
+
+
+# Tests the correct Data container ROI compression for
+# various combinations of ROIs / sensor dimensions.
+@pytest.mark.parametrize("reference_channels", [1, 2])
+@pytest.mark.parametrize("image_roi", [[10, 10], [1], [13], [2, 10, 3, 2]])
+def test_set_dims_from_sensor_compression(reference_channels, image_roi):
+    dynamic_steps = 6
+    nframes = 10
+    cam = SensorFactory.create_sensor("MockCam", {"number_measurements": nframes, "image_roi": image_roi})
+    # Bypass the roi parsing mechanism of the Mock Sensor to test the behaviour of the Data cotainer. 
+    cam.roi_shape = image_roi
+    data = Data({"averaging_mode": "spread",
+                 "dynamic_steps": dynamic_steps,
+                 "live_compression": True,
+                 "reference_channels": reference_channels})
+    data.set_dims_from_sensor(cam)
+    data.create_array()
+    assert data.data.shape == (reference_channels, dynamic_steps, int(nframes/reference_channels), 1)
+    data.update_data(cam.acquire_data(), 0, 0)
+
+
+# No dimension of the data container can be zero
+# => This would reduce the overall size of the array to 0.
+def test_data_container_refuse_0_dyn_steps():
+    dynamic_steps = 0
+    with pytest.raises(ValueError):
+        data = Data({"averaging_mode": "spread", "dynamic_steps": dynamic_steps})


### PR DESCRIPTION
**This PR addresses two open issues:**

# 🛠️ Issue 1: Invalid shape in compress mode (#24)
The `compress` mode previously averaged over ROI dimensions but dropped the last axis, resulting in shapes like `[2, 1, 50]` instead of `[2, 1, 50, 1]`  (example shapes => last dimension get dropped, even though it should not). This broke downstream analysis relying on consistent shape semantics. See #24 

Fix:

`compress` is now remapped internally to `live_compression`, which produces the correct shape.

A deprecation warning is issued if `compress` is used, guiding users to migrate.

Additionally, a few parameter sanity checks were added to catch misconfigurations earlier and reduce the chance of silent errors.

# 🧪 Issue 2: No test coverage (#23)
Introduced a `tests/` folder and added basic tests using **pytest**.

These tests focus on verifying the correct behavior of the compression modes and data shape consistency, especially for the edge cases discussed above.

This lays the foundation for growing a test suite to improve confidence in future changes.

Let me know if further test cases or documentation updates are needed.