### PR TITLE
Fix dtype mismatch in DataContainer when live_compression: true by forcing float64

### DIFF
--- a/qupyt/measurement_logic/data_handling.py
+++ b/qupyt/measurement_logic/data_handling.py
@@ -79,6 +79,7 @@ class Data(ConfigurationMixin):
         # Specifics have then to be dealt with in each class.
         if self.live_compression:
             self.roi_shape = [1]
+            self.data_type = float
         if self.averaging_mode == "sum":
             data_array_dim = [
                 self.reference_channels,


### PR DESCRIPTION
# Description

This PR fixes a runtime type error that occurs when using live_compression=True with a sensor configured to output uint32 (or other integer types). #26 

## Problem

Please refer to #26 for a description of the problem.

## Implementation

The fix is a single-line change that sets the internal `dtype` to `float` during `DataContainer` initialization if compression is enabled.

## Test

The reproduction files referenced in the original issue now complete without problem.