### PR TITLE
Added set_phase function to configure phase settings in VisaSignalSource

### DIFF
--- a/qupyt/hardware/signal_sources.py
+++ b/qupyt/hardware/signal_sources.py
@@ -201,6 +201,7 @@ class VisaSignalSource(visa_handler.VisaObject, SignalSource):
         self.address = address
         visa_handler.VisaObject.__init__(self, address, device_type)
         SignalSource.__init__(self, configuration)
+        self.attribute_map['phase'] = self.set_phase
 
     @validate_call
     @coerce_device_config_shape
@@ -224,6 +225,19 @@ class VisaSignalSource(visa_handler.VisaObject, SignalSource):
         logging.info(
             f"{self.s_type} set frequency channel {channel} to".ljust(65, ".")
             + f"{freq}"
+        )
+
+    @validate_call
+    @coerce_device_config_shape
+    @loop_inputs
+    def set_phase(self, phase: ParameterInput) -> None:
+        channel, phase = phase
+        self.instance.write(self.command[f"SetPhase{channel}"] + str(phase))
+        #self.opc_wait()
+        sleep(0.5)
+        logging.info(
+            f"{self.s_type} set phase channel {channel} to".ljust(65, ".")
+            + f"{phase}"
         )
 
 

--- a/qupyt/hardware/visa_handler.py
+++ b/qupyt/hardware/visa_handler.py
@@ -118,6 +118,10 @@ class VisaObject:
                 "GetAmpl1": "SOURce1:VOLTage:LEVel:IMMediate:AMPLitude?",
                 "SetFreq1": "SOURce1:FREQuency:FIXed ",
                 "GetFreq1": "SOURce1:FREQuency:FIXed?",
+                "SetPhase1": "SOURce1:PHASe ",
+                "SetAmpl2": "SOURce2:VOLTage:LEVel:IMMediate:AMPLitude ",
+                "SetFreq2": "SOURce2:FREQuency:FIXed ",
+                "SetPhase2": "SOURce2:PHASe ",
                 # The Tek AFG does not implement an OPC.
                 # We therefore skip the waiting time and
                 # Query impedance which will alwasy return


### PR DESCRIPTION
Added `set_phase` function to configure phase settings in `VisaSignalSource`

It includes a short delay (sleep(0.5)) to ensure the device has time to process the command.
