### PR TITLE
Add r&s sma100 - as one class with SMB

### DIFF
--- a/qupyt/hardware/signal_sources.py
+++ b/qupyt/hardware/signal_sources.py
@@ -70,6 +70,7 @@ class DeviceFactory:
             "Mock",
             "SRS",
             "SMB",
+            "SMA"
             "Rigol",
             "TekAWG",
             "TekAFG",
@@ -92,6 +93,12 @@ class DeviceFactory:
             if device_info["device_type"] == "Mock":
                 return MockSignalSource(device_info["address"], device_info["config"])
             if device_info["device_type"] == "SMB":
+                return SMBVisaSignalSource(
+                    device_info["address"],
+                    device_info["device_type"],
+                    device_info["config"],
+                )
+            if device_info["device_type"] == "SMA":
                 return SMBVisaSignalSource(
                     device_info["address"],
                     device_info["device_type"],
@@ -362,6 +369,80 @@ class SMBVisaSignalSource(VisaSignalSource):
         self.instance.write("SOURce1:FREQ:MODE LIST")
         self.opc_wait()
         logging.info("%s[done]", "SMB set slist values.".ljust(65, "."))
+
+class SMAVisaSignalSource(VisaSignalSource):
+    """
+    SignaSource implementation for devices that implement
+    the VISA protocol and configure a switchable frequency list
+    """
+
+    def __init__(
+        self, address: str, device_type: str, configuration: Dict[str, Any]
+    ) -> None:
+        self.slist_frequencies: List[float] = []
+        self.slist_amplitudes: List[float] = []
+        super().__init__(address, device_type, configuration)
+        self.attribute_map["slist_frequencies"] = self._set_slist_frequencies
+        self.attribute_map["slist_amplitudes"] = self._set_slist_amplitudes
+
+    def _set_slist_frequencies(self, slist_frequencies: List[float]) -> None:
+        self.slist_frequencies = slist_frequencies
+        if len(self.slist_frequencies) != 0 and (
+            len(self.slist_amplitudes) == len(self.slist_frequencies)
+        ):
+            self._configure_slist()
+
+    def _set_slist_amplitudes(self, slist_amplitudes: List[float]) -> None:
+        self.slist_amplitudes = slist_amplitudes
+        if len(self.slist_amplitudes) != 0 and (
+            len(self.slist_amplitudes) == len(self.slist_frequencies)
+        ):
+            self._configure_slist()
+
+    def _configure_slist(self) -> None:
+        self.instance.write("*RST")
+        self.opc_wait()
+        self.instance.write("OUTP:STAT ON")
+        self.opc_wait()
+        self.instance.write("SOURce:FREQ:MODE CW")
+        self.opc_wait()
+        # Delete list if exists.
+        if "SyncList" in self.instance.query('SOURce:LIST:CAT?'):
+            self.instance.write('SOURce:LIST:DEL "SyncList"')
+        # create list
+        self.instance.write('SOURce:LIST:SEL "SyncList"')
+        self.opc_wait()
+
+        #set dwell time
+        self.instance.write("SOURce:LIST_DWEL 2ms")
+        self.opc_wait()
+
+        # write frequency to list first row in arg first one being the NV
+        # second one the overhauser-frequency
+        set_slist_frequencies = f"SOURce:LIST:FREQ {self.slist_frequencies[0]} Hz"
+        for slist_freq in self.slist_frequencies[1:]:
+            set_slist_frequencies += f", {slist_freq} Hz"
+        self.instance.write(set_slist_frequencies)
+        self.opc_wait()
+
+        # write amp to list first row in arg first one being the NV
+        # second one the overhauser-amp
+        set_slist_amplitudes = f"SOURce:LIST:POW {self.slist_amplitudes[0]} dBm"
+        for slist_ampl in self.slist_amplitudes[1:]:
+            set_slist_amplitudes += f", {slist_ampl} dBm"
+        self.instance.write(set_slist_amplitudes)
+        self.opc_wait()
+
+        # set list mode to step not auto
+        self.instance.write("SOURce:LIST:MODE STEP")
+        self.opc_wait()
+        # set trigger type to external
+        self.instance.write("SOURce:LIST:TRIG:SOUR EXT")
+        self.opc_wait()
+        self.instance.write("SOURce:FREQ:MODE LIST")
+        self.opc_wait()
+        logging.info("%s[done]", "SMB set slist values.".ljust(65, "."))
+
 
 
 class WindFreakSNV(SignalSource):

--- a/qupyt/hardware/signal_sources.py
+++ b/qupyt/hardware/signal_sources.py
@@ -70,7 +70,7 @@ class DeviceFactory:
             "Mock",
             "SRS",
             "SMB",
-            "SMA"
+            "SMA",
             "Rigol",
             "TekAWG",
             "TekAFG",
@@ -92,18 +92,13 @@ class DeviceFactory:
                 return WindFreakSHDMini(device_info["address"], device_info["config"])
             if device_info["device_type"] == "Mock":
                 return MockSignalSource(device_info["address"], device_info["config"])
-            if device_info["device_type"] == "SMB":
-                return SMBVisaSignalSource(
+            if device_info["device_type"] == "SMB" or device_info["device_type"] == "SMA":
+                return SMAandSMBVisaSignalSource(
                     device_info["address"],
                     device_info["device_type"],
                     device_info["config"],
                 )
-            if device_info["device_type"] == "SMA":
-                return SMBVisaSignalSource(
-                    device_info["address"],
-                    device_info["device_type"],
-                    device_info["config"],
-                )
+
             if device_info["device_type"] == "Rigol":
                 return RigolSignalSource(
                     device_info["address"],
@@ -301,76 +296,7 @@ class RigolSignalSource(VisaSignalSource, PhaseMixin):
             self.instance.write(self.command[f"SetBurstMode{channel}"] + "GAT")
 
 
-class SMBVisaSignalSource(VisaSignalSource):
-    """
-    SignaSource implementation for devices that implement
-    the VISA protocol and configure a switchable frequency list
-    """
-
-    def __init__(
-        self, address: str, device_type: str, configuration: Dict[str, Any]
-    ) -> None:
-        self.slist_frequencies: List[float] = []
-        self.slist_amplitudes: List[float] = []
-        super().__init__(address, device_type, configuration)
-        self.attribute_map["slist_frequencies"] = self._set_slist_frequencies
-        self.attribute_map["slist_amplitudes"] = self._set_slist_amplitudes 
-
-    def _set_slist_frequencies(self, slist_frequencies: List[float]) -> None:
-        self.slist_frequencies = slist_frequencies
-        if len(self.slist_frequencies) != 0 and (
-            len(self.slist_amplitudes) == len(self.slist_frequencies)
-        ):
-            self._configure_slist()
-
-    def _set_slist_amplitudes(self, slist_amplitudes: List[float]) -> None:
-        self.slist_amplitudes = slist_amplitudes
-        if len(self.slist_amplitudes) != 0 and (
-            len(self.slist_amplitudes) == len(self.slist_frequencies)
-        ):
-            self._configure_slist()
-
-    def _configure_slist(self) -> None:
-        self.instance.write("*RST")
-        self.opc_wait()
-        self.instance.write("OUTP ON")
-        self.opc_wait()
-        self.instance.write("SOURce1:FREQ:MODE CW")
-        self.opc_wait()
-        # Delete list if exists.
-        if "SyncList" in self.instance.query('SOURce1:LIST:CAT?'):
-            self.instance.write('SOURce1:LIST:DEL "SyncList"')
-        # create list
-        self.instance.write('SOURce1:LIST:SEL "SyncList"')
-        self.opc_wait()
-
-        # write frequency to list first row in arg first one being the NV
-        # second one the overhauser-frequency
-        set_slist_frequencies = f"SOURce1:LIST:FREQ {self.slist_frequencies[0]} Hz"
-        for slist_freq in self.slist_frequencies[1:]:
-            set_slist_frequencies += f", {slist_freq} Hz"
-        self.instance.write(set_slist_frequencies)
-        self.opc_wait()
-
-        # write amp to list first row in arg first one being the NV
-        # second one the overhauser-amp
-        set_slist_amplitudes = f"SOURce1:LIST:POW {self.slist_amplitudes[0]} dBm"
-        for slist_ampl in self.slist_amplitudes[1:]:
-            set_slist_amplitudes += f", {slist_ampl} dBm"
-        self.instance.write(set_slist_amplitudes)
-        self.opc_wait()
-
-        # set list mode to step not auto
-        self.instance.write("SOURce1:LIST:MODE STEP")
-        self.opc_wait()
-        # set trigger type to external
-        self.instance.write("SOURce1:LIST:TRIG:SOUR EXT")
-        self.opc_wait()
-        self.instance.write("SOURce1:FREQ:MODE LIST")
-        self.opc_wait()
-        logging.info("%s[done]", "SMB set slist values.".ljust(65, "."))
-
-class SMAVisaSignalSource(VisaSignalSource):
+class SMAandSMBVisaSignalSource(VisaSignalSource):
     """
     SignaSource implementation for devices that implement
     the VISA protocol and configure a switchable frequency list
@@ -414,7 +340,6 @@ class SMAVisaSignalSource(VisaSignalSource):
         self.opc_wait()
 
         #set dwell time
-        self.instance.write("SOURce:LIST_DWEL 2ms")
         self.opc_wait()
 
         # write frequency to list first row in arg first one being the NV
@@ -441,7 +366,7 @@ class SMAVisaSignalSource(VisaSignalSource):
         self.opc_wait()
         self.instance.write("SOURce:FREQ:MODE LIST")
         self.opc_wait()
-        logging.info("%s[done]", "SMB set slist values.".ljust(65, "."))
+        logging.info("%s[done]", "SMB or SMA set slist values.".ljust(65, "."))
 
 
 

--- a/qupyt/hardware/visa_handler.py
+++ b/qupyt/hardware/visa_handler.py
@@ -23,7 +23,7 @@ class VisaObject:
         handle: visa adress of signal source
         s_type: source type (SRS, RS)...
         """
-        self.known_s_types = ["SRS", "SMB", "Rigol", "TekAWG", "TekAFG"]
+        self.known_s_types = ["SRS", "SMA", "SMB", "Rigol", "TekAWG", "TekAFG"]
         self.handle = handle
         self.s_type = s_type
         if self.s_type not in self.known_s_types:
@@ -70,6 +70,15 @@ class VisaObject:
             }
 
         elif self.s_type == "SMB":
+            self.command = {
+                "SetAmpl1": "POW ",
+                "GetAmpl1": "POW?",
+                "SetFreq1": "FREQ ",
+                "GetFreq1": "FREQ?",
+                "OPC": "*OPC?",
+            }
+
+        elif self.s_type == "SMA":
             self.command = {
                 "SetAmpl1": "POW ",
                 "GetAmpl1": "POW?",


### PR DESCRIPTION
After the discussions in PR #38 I suggest adding the SMA as an option for a signal source, but having SMA and SMB point onto the same `class SMAandSMAVisaSignalSource`. 

This was tested on a Tektronix SMA with a Signal Hound Spectrum Analyzer during an ODMR sequence and performed exactly as planned. It did work for both SOURce1 and SOURce and I can't explain why we had errors before. 

I suggest, @KarDB to test it on a Tektronix SMB signal source before commit.