### PR TITLE
Fix Windows race condition when reading instruction YAML (throwing two FileNotFound errors)

### DIFF
--- a/qupyt/main.py
+++ b/qupyt/main.py
@@ -9,9 +9,10 @@ import threading
 import traceback
 import os
 import platform
+import time
 from datetime import date
 from time import sleep
-from queue import Queue
+from queue import Queue, Empty
 from typing import Optional
 from pathlib import Path
 
@@ -101,23 +102,60 @@ def _set_ready() -> None:
 def parse_input() -> None:
     static_devices = DeviceHandler({})
     dynamic_devices = DynamicDeviceHandler({}, number_dynamic_steps=1)
+    processed_files = set()  # track files already picked from the queue
     while True:
         if queue.empty():
             static_devices.update_devices({})
             dynamic_devices.update_devices({})
             _set_ready()
             event_thread.wait()
+            continue
         try:
             _set_busy()
+
+            # Get the next file from the queue
+            try:
+                instruction_file = queue.get(timeout=1)
+            except Empty:
+                continue  # no file yet, check again
+
+            # Track files by full path + last modification time
+            instruction_path = Path(instruction_file)
+            if not instruction_path.exists():
+                # File might have been removed; skip
+                continue
+            file_key = (str(instruction_path), os.path.getmtime(instruction_path))
+            if file_key in processed_files:
+                continue  # already processed this instance
+            processed_files.add(file_key)
+
             logging.info("STARTED NEW MEASUREMENT".ljust(65, "=") + "[START]")
-            instruction_file = queue.get()
-            with open(instruction_file, "r", encoding="utf-8") as file:
-                params = yaml.safe_load(file)
-            os.rename(instruction_file, instruction_file + "_running")
+
+            # Retry reading the file in case it's still being written
+            for attempt in range(3):
+                try:
+                    with open(instruction_file, "r", encoding="utf-8") as file:
+                        params = yaml.safe_load(file)
+                    break
+                except FileNotFoundError:
+                    time.sleep(0.1)  # wait 100ms
+            else:
+                print(f"File still missing after retries, skipping: {instruction_file}")
+                processed_files.discard(file_key)
+                continue
+
+            # Use timestamped _running filename to avoid collisions
+            timestamp = int(time.time() * 1000)  # milliseconds
+            running_file = f"{instruction_file}_running_{timestamp}"
+            os.replace(instruction_file, running_file)
+
+            # Update parameters
             parameter_update = write_user_ps(
                 Path(params["ps_path"]), params["pulse_sequence"]
             )
             update_params_dict(params, parameter_update)
+
+            # Create measurement objects
             synchroniser = SynchroniserFactory.create_synchroniser(
                 params["synchroniser"]["type"],
                 params["synchroniser"]["config"],
@@ -126,16 +164,29 @@ def parse_input() -> None:
             sensor = SensorFactory.create_sensor(
                 params["sensor"]["type"], params["sensor"]["config"]
             )
+
+            # Update devices
             static_devices.update_devices(params["static_devices"])
             dynamic_devices.number_dynamic_steps = int(params["dynamic_steps"])
             dynamic_devices.update_devices(params["dynamic_devices"])
+
+            # Run the measurement
             success_status = run_measurement(
                 static_devices, dynamic_devices, sensor, synchroniser, params
             )
+
+            # Handle post-measurement file renames
             if success_status == "success":
-                os.remove(instruction_file + "_running")
+                if os.path.exists(running_file):
+                    os.remove(running_file)
             elif success_status == "failed":
-                os.rename(instruction_file + "_running", instruction_file + "_failed")
+                failed_file = f"{instruction_file}_failed_{timestamp}"
+                if os.path.exists(running_file):
+                    os.replace(running_file, failed_file)
+
+            # Allow the same filename to be processed again in future
+            processed_files.discard(file_key)
+
         except Exception:
             logging.exception("Excpetion in main measurement loop")
             traceback.print_exc()


### PR DESCRIPTION
Windows file watchers can enqueue events before the writer/renamer has fully
finished, leading to intermittent FileNotFoundError / read failures.

**What changed**
Added a small retry mechanism when reading instruction YAML files to tolerate short-lived “missing file” windows.
Updated the “running” rename behavior to use a timestamped filename to prevent collisions and improve traceability.
Added lightweight de-duplication of queued events so the same file instance isn’t processed multiple times due to multiple watcher events.

**Why**
This eliminates a timing/race issue specific to Windows file event ordering and improves robustness when the producer writes + moves/renames files quickly.

**How to test**
On Windows, start the measurement loop and have an external process rapidly create/write/move YAML instruction files into the waiting room.
Verify the loop reliably picks up instructions without the errors.
Confirm success/failed handling still results in expected cleanup/renames. 

I tested it succesfullyon my setup and Laras.

Ideally, please also test for Linux, if everything is still working!