### PR TITLE
Add support for pulse sequences sweeps

### DIFF
--- a/qupyt/hardware/synchronisers.py
+++ b/qupyt/hardware/synchronisers.py
@@ -261,7 +261,7 @@ class AWGenerator(VisaObject, Synchroniser):
             for marker in self.marker_channels:
                 self._set_marker_amplitude(
                     channel, marker, self.marker_amplitude)
-        print("Configuring AWG".ljust(65, ".") + colored(" [done]", "green"))
+        print("\nConfiguring AWG".ljust(65, ".") + colored(" [done]", "green"))
 
     def _upload_waveform(self, wavename: str, waveform: np.ndarray) -> None:
         self.instance.write('wlist:waveform:delete "' + wavename + '"')

--- a/qupyt/hardware/synchronisers.py
+++ b/qupyt/hardware/synchronisers.py
@@ -98,7 +98,7 @@ class Synchroniser(ABC, ConfigurationMixin):
     one measurement step. To do this they need a pulse sequence they are
     supposed to play during the measurement. This pulse sequence is read
     from a yaml file from its default location
-    (~/.qupyt/sequences/sequence.yaml). The specifics of how a pulse sequence
+    (~/.qupyt/sequences/sequence_0.yaml). The specifics of how a pulse sequence
     is played depends on the synchroniser (Tektronix AWG, PulseStreamer, ...)
     and have to be dealt with in the implementation of this class for the
     synchroniser in question.
@@ -130,7 +130,7 @@ class Synchroniser(ABC, ConfigurationMixin):
         self.address = address
 
     @abstractmethod
-    def load_sequence(self) -> None:
+    def load_sequence(self, ps_yaml_file: Path) -> None:
         """
         Load the YAML formatted pulse sequence from its default location
         (see above), and parse it to the specifics of the synchroniser. Finally
@@ -237,12 +237,11 @@ class AWGenerator(VisaObject, Synchroniser):
         self.instance.write("trigger:immediate atrigger")
         logging.info("Sent trigger to AWG".ljust(65, ".") + "[done]")
 
-    def load_sequence(self) -> None:
+    def load_sequence(self, ps_yaml_file: str = "sequence_0.yaml") -> None:
         self.stop()
         self._clear_awg()
         sequence_translator = PulseSequenceYaml(
-            self.channel_mapping, self.channels, samprate=self.samprate
-        )
+            self.channel_mapping, self.channels, samprate=self.samprate, yaml_file = ps_yaml_file)
         sequence_translator.translate_yaml_to_numeric_instructions()
         self._load_sequence_block(get_seq_dir() / "sequence.npz")
         self._upload_waveforms()
@@ -689,14 +688,14 @@ class PStreamer(Synchroniser):
                 "Warning (plot_sequence()): No sequence is streaming in the PulseStreamer."
             )
 
-    def load_sequence(self) -> None:
+    def load_sequence(self, ps_yaml_file: str = "sequence_0.yaml") -> None:
         """
         Calls the WriteDigSig() function and loads the corresponding sequences
         to the respective channels.
         """
         try:
             # Selected folder:
-            self.yaml_file = set_up.get_seq_dir() / "sequence.yaml"
+            self.yaml_file = set_up.get_seq_dir() / ps_yaml_file
             with open(self.yaml_file, "r", encoding="utf-8") as file:
                 full_pulse_list = yaml.load(file, Loader=yaml.FullLoader)
             sequence_order = full_pulse_list["sequencing_order"]
@@ -816,9 +815,9 @@ class MockGenerator(Synchroniser):
     def open(self) -> None:
         logging.info("Opened MockSynchroniser".ljust(65, ".") + "[done]")
 
-    def load_sequence(self) -> None:
+    def load_sequence(self, ps_yaml_file: str = "sequence_0.yaml") -> None:
         try:
-            self.yaml_file = set_up.get_seq_dir() / "sequence.yaml"
+            self.yaml_file = set_up.get_seq_dir() / ps_yaml_file
             with open(self.yaml_file, "r", encoding="utf-8") as file:
                 full_pulse_list = yaml.load(file, Loader=yaml.FullLoader)
             total_duration = (
@@ -948,8 +947,8 @@ class PulseBlaster(Synchroniser):
     def open(self) -> None:
         self.configure_pb()
 
-    def load_sequence(self) -> None:
-        yaml_sequence_transpiler = PulseBlasterSequence(self.channel_mapping)
+    def load_sequence(self, ps_yaml_file: str = "sequence_0.yaml") -> None:
+        yaml_sequence_transpiler = PulseBlasterSequence(self.channel_mapping, ps_yaml_file)
         yaml_sequence_transpiler.parse_pulse_sequence_file()
         channel_bit_mask, pulse_duration_list = yaml_sequence_transpiler.compile()
         self.program_pb(channel_bit_mask, pulse_duration_list)

--- a/qupyt/measurement_logic/data_handling.py
+++ b/qupyt/measurement_logic/data_handling.py
@@ -15,11 +15,13 @@ class Data(ConfigurationMixin):
         self.number_measurements: int
         self.data_type: type
         self.live_compression: bool = False
+        self.number_pulse_sequences: int = 1
         self.save_in_chunks: int = 0
         self.reference_channels: int = 2
         self.data: np.ndarray
         self.attribute_map = {
             "dynamic_steps": self._set_number_dynamic_steps,
+            "ps_steps": self._set_number_pulse_sequences,
             "averaging_mode": self._set_averaging_mode,
             "number_measurements": self._set_number_measurements,
             "roi_shape": self._set_roi_shape,
@@ -52,6 +54,9 @@ class Data(ConfigurationMixin):
             If you measure just one step, this is still ONE dynamic step. The first of one.""")
         self.number_dynamic_steps = int(number_dynamic_steps)
 
+    def _set_number_pulse_sequences(self, number_pulse_sequences: int) -> None:
+        self.number_pulse_sequences = int(number_pulse_sequences)
+
     def _set_averaging_mode(self, averaging_mode: str) -> None:
         self.averaging_mode = str(averaging_mode)
 
@@ -83,6 +88,7 @@ class Data(ConfigurationMixin):
         if self.averaging_mode == "sum":
             data_array_dim = [
                 self.reference_channels,
+                self.number_pulse_sequences,
                 self.number_dynamic_steps,
                 1,
                 *self.roi_shape,
@@ -94,6 +100,7 @@ class Data(ConfigurationMixin):
                 Please make sure the number of measurements you want to recored can be distributed accross the reference channels. (I.e. number_measurements is divisible by reference_cannels""")
             data_array_dim = [
                 self.reference_channels,
+                self.number_pulse_sequences,
                 self.number_dynamic_steps,
                 int(measurements_per_channel),
                 *self.roi_shape,
@@ -111,38 +118,38 @@ class Data(ConfigurationMixin):
         )
         self.data = np.zeros(data_array_dim, dtype=getattr(self, "data_type", float))
 
-    def update_data(self, data: np.ndarray, dynamic_step: int, avg_step: int) -> None:
+    def update_data(self, data: np.ndarray, ps_step: int, dynamic_step: int, avg_step: int) -> None:
         if self.save_in_chunks != 0 and avg_step % self.save_in_chunks == 0:
             self.save(f"save_chunk_{avg_step}.npy")
             self.create_array()
         if self.live_compression:
-            self._update_data_compressed(data, dynamic_step)
+            self._update_data_compressed(data, ps_step, dynamic_step)
         else:
-            self._update_data_full(data, dynamic_step)
+            self._update_data_full(data, ps_step, dynamic_step)
 
-    def _update_data_full(self, data: np.ndarray, dynamic_step: int) -> None:
+    def _update_data_full(self, data: np.ndarray, ps_step: int, dynamic_step: int) -> None:
         if self.averaging_mode == "sum":
             for i in range(self.reference_channels):
-                self.data[i, dynamic_step] += data[i :: self.reference_channels].sum(
+                self.data[i, ps_step, dynamic_step] += data[i :: self.reference_channels].sum(
                     axis=0
                 )
             # np.save("C:/Users/ge54vec/.qupyt/data", self.data)
         elif self.averaging_mode == "spread":
             for i in range(self.reference_channels):
-                self.data[i, dynamic_step] += data[i :: self.reference_channels]
+                self.data[i, ps_step, dynamic_step] += data[i :: self.reference_channels]
                 # np.save("C:/Users/ge54vec/.qupyt/data", self.data)
 
-    def _update_data_compressed(self, data: np.ndarray, dynamic_step: int) -> None:
+    def _update_data_compressed(self, data: np.ndarray, ps_step: int, dynamic_step: int) -> None:
         if self.averaging_mode == "sum":
             for i in range(self.reference_channels):
                 ndim = data.ndim
-                self.data[i, dynamic_step] += (
+                self.data[i, ps_step, dynamic_step] += (
                     data[i :: self.reference_channels].mean(axis=tuple(range(1, ndim))).sum(axis=0)
                 )
         elif self.averaging_mode == "spread":
             for i in range(self.reference_channels):
                 ndim = data.ndim
-                self.data[i, dynamic_step] += (
+                self.data[i, ps_step, dynamic_step] += (
                     data[i :: self.reference_channels].mean(axis=tuple(range(1, ndim))).reshape(-1, 1)
                 )
 

--- a/qupyt/measurement_logic/run_measurement.py
+++ b/qupyt/measurement_logic/run_measurement.py
@@ -16,6 +16,7 @@ from qupyt.measurement_logic.data_handling import Data
 from qupyt.hardware.synchronisers import Synchroniser
 from qupyt.hardware.sensors import Sensor
 from qupyt._version import __version__ as qupyt_version
+from qupyt.set_up import get_seq_dir
 
 
 def run_measurement(
@@ -27,6 +28,7 @@ def run_measurement(
 ) -> str:
     static_devices.set_all_params()
     iterator_size = int(params.get("dynamic_steps", 1))
+    ps_iterator_size = int(params.get("pulse_sequence_steps", 1))
     mid = datetime.today().strftime("%Y-%m-%d-%H-%M-%S")
     return_status = "all_fail"
     try:
@@ -34,22 +36,26 @@ def run_measurement(
         data_container.set_dims_from_sensor(sensor)
         data_container.create_array()
 
-        synchroniser.open()
-        synchroniser.stop()
-        synchroniser.load_sequence()
-        synchroniser.run()
-        sleep(0.1)
-        sensor.open()
-        sleep(0.5)
-        for itervalue in tqdm(range(iterator_size)):
-            dynamic_devices.next_dynamic_step()
+        for ps_itervalue in tqdm(range(ps_iterator_size)):
+            synchroniser.open()
+            synchroniser.stop()
+            synchroniser.load_sequence(get_seq_dir() / f"sequence_{ps_itervalue}.yaml")
+            synchroniser.run()
             sleep(0.1)
-            for avg in tqdm(
-                range(int(params["averages"])), leave=itervalue == (iterator_size - 1)
-            ):
-                sleep(float(params.get("sleep", 0)))
-                data = sensor.acquire_data(synchroniser)
-                data_container.update_data(data, itervalue, avg)
+            sensor.open()
+            sleep(0.5)
+            for itervalue in tqdm(range(iterator_size), leave=(ps_itervalue == ps_iterator_size - 1)):
+                dynamic_devices.next_dynamic_step()
+                sleep(0.1)
+                for avg in tqdm(
+                        range(int(params["averages"])),
+                        leave=(itervalue == (iterator_size - 1)) and (ps_itervalue == (ps_iterator_size - 1)),
+                ):
+
+                    sleep(float(params.get("sleep", 0)))
+                    data = sensor.acquire_data(synchroniser)
+                    data_container.update_data(data, ps_itervalue, itervalue, avg)
+            dynamic_devices.current_dynamic_step = 0
         return_status = "success"
     except Exception as e:
         print(f"exc {e}")

--- a/qupyt/pulse_sequences/SequenceDesigner.py
+++ b/qupyt/pulse_sequences/SequenceDesigner.py
@@ -20,7 +20,7 @@ class PulseSequenceYaml:
         #  There is one analog channel per source but mulitple makers etc.
         awg_sources: list[int],
         samprate: float = 5e9,
-        yaml_file: Path = get_seq_dir() / "sequence.yaml",
+        yaml_file: Path = get_seq_dir() / "sequence_0.yaml",
     ) -> None:
         self.yaml_file = yaml_file
         self.awg_sources = awg_sources

--- a/qupyt/pulse_sequences/SequenceDesigner.py
+++ b/qupyt/pulse_sequences/SequenceDesigner.py
@@ -96,12 +96,13 @@ class PulseSequence:
     ) -> None:
         self.samp_rate = samprate  # samples per second
         self.min_time = 1 / samprate
-        self.num_points = int(samprate * duration * 1e-6)
+        points = samprate * duration * 1e-6
+        self.num_points = int(round(points))
         self.time = np.linspace(0, duration, self.num_points)  # in microseconds
         self.numseqs = numseqs
         self.awg_sources = awg_sources
 
-        if self.num_points != samprate * duration * 10**-6:
+        if not np.isclose(points, self.num_points, rtol=0.0, atol=1e-9):
             print(
                 colored(
                     "WARNING! the sequence duration is not an integer multiple of samples".ljust(

--- a/qupyt/pulse_sequences/yaml_sequence.py
+++ b/qupyt/pulse_sequences/yaml_sequence.py
@@ -45,11 +45,13 @@ class YamlSequence:
             }
             self.counter[sequence_block][pulse_channel] += 1
 
-    def write(self) -> None:
+    def write(self, sequence_number: int | None = None) -> None:
+        sequence_number_string = "0" if sequence_number is None else str(sequence_number)
         file_path = set_up.get_seq_dir()
+        file_name = f"sequence_{sequence_number_string}.yaml"
         self.pulse_sequence["sequencing_order"] = self.sequencing_order
         self.pulse_sequence["sequencing_repeats"] = self.sequencing_repeats
-        with open(file_path / "sequence.yaml", "w", encoding="utf-8") as file:
+        with open(file_path / file_name, "w", encoding="utf-8") as file:
             yaml.dump(self.pulse_sequence, file)
 
 

--- a/source/example_configs/ODMR.yaml
+++ b/source/example_configs/ODMR.yaml
@@ -37,6 +37,7 @@ synchroniser:
     LASER: 8
     READ: 1
 
+pulse_sequence_steps: &ps_steps 20
 dynamic_steps: &n_dynamic_steps 10
 
 # List devices that are supposed to update their
@@ -83,11 +84,15 @@ data:
   dynamic_steps: *n_dynamic_steps
   compress: false
   reference_channels: 2
+  ps_steps: *ps_steps
 
-ps_path: './odmr_sample_pulse_sequence.py'
+ps_path: './example_pulse_sequences/odmr.py'
 pulse_sequence:
+  pulse_sequence_steps: *ps_steps
+  sweep_param: 'laser_duration'
+  sweep_values: [10, 100]
   mw_duration: 20
-  laserduration: 50
+  laser_duration: 50
   readout_time: 8
   referenced_measurements: *nframes
   max_framerate: 10000

--- a/source/example_pulse_sequences/odmr.py
+++ b/source/example_pulse_sequences/odmr.py
@@ -7,29 +7,87 @@ of the hardware used.
 # pylint: disable=logging-format-interpolation
 # pylint: disable=logging-fstring-interpolation
 # pylint: disable=logging-not-lazy
+import logging
 from qupyt.pulse_sequences.yaml_sequence import YamlSequence
 
 
 def generate_sequence(params: dict):
     """
-    Interace function to be called when this module
+    Interface function to be called when this module
     is imported into the running python instance.
     """
-    return gen_esr(
-        params.get('mw_duration', 10),
-        params.get('laserduration', 10),
-        params.get('readout_time', 1),
-        params.get('referenced_measurements', 100),
-        params.get('max_framerate', 1000)
-    )
+    pulse_sequence_steps = int(params.get("pulse_sequence_steps", 1))
+
+    sweep_param_raw = params.get("sweep_param", None)
+    sweep_param = None if sweep_param_raw in (None, "") else str(sweep_param_raw)
+    sweep_values = params.get("sweep_values", None)
+
+    print(sweep_param, pulse_sequence_steps, sweep_values)
+
+    if sweep_param is not None and sweep_param not in params:
+        logging.warning(
+            "generate_sequence(): sweep_param=%r was provided, but no such key exists in params.",
+            sweep_param,
+        )
+
+    def _value_for_step(step: int):
+        if sweep_values is None:
+            return None
+
+        if isinstance(sweep_values, (list, tuple)):
+            values = list(sweep_values)
+        else:
+            values = [sweep_values]
+
+        if pulse_sequence_steps <= 1:
+            return values[-1]
+
+        # Endpoint form: [start, stop] -> interpolate across all steps
+        if len(values) == 2:
+            start, stop = float(values[0]), float(values[1])
+            frac = step / (pulse_sequence_steps - 1)
+            return start + (stop - start) * frac
+
+        # Explicit list form: must match steps
+        if len(values) == pulse_sequence_steps:
+            return values[step]
+
+        logging.warning(
+            "generate_sequence(): sweep_values must be either [start, stop] or have length == pulse_sequence_steps. "
+            "Got length %d with pulse_sequence_steps=%d. No sweep applied.",
+            len(values),
+            pulse_sequence_steps,
+        )
+        return None
+
+    for ps_step in range(pulse_sequence_steps):
+        print('PS_step', ps_step, 'sequence_setps',pulse_sequence_steps)
+        if sweep_param is None:
+            ps_step = 0
+        if sweep_param is not None and sweep_param in params:
+            v = _value_for_step(ps_step)
+            if v is not None:
+                params[sweep_param] = v
+
+        backup_params = gen_esr(
+            params.get("mw_duration", 10),
+            params.get("laser_duration", 10),
+            params.get("readout_time", 1),
+            params.get("referenced_measurements", 100),
+            params.get("max_framerate", 1000),
+            ps_step,
+        )
+    return backup_params
+
 
 
 def gen_esr(
         mw_duration: float,
-        laserduration: float,
+        laser_duration: float,
         readout_time: float,
         referenced_measurements: int,
-        max_framerate: float = 10000
+        max_framerate: float = 10000,
+        ps_step: int= 0
 ) -> dict:
     """
     Implementation of the ESR pulsesequence.
@@ -49,7 +107,7 @@ def gen_esr(
     # We compute the time it takes to perform the measurement step,
     # and double the time needed to take into account the reference.
     time_half = buffer_between_pulses * 3 + \
-        mw_duration + laserduration + readout_and_repol_gap
+        mw_duration + laser_duration + readout_and_repol_gap
     time_half = max(time_half, 1/max_framerate * 1e6)
     total_time = 2 * time_half
 
@@ -82,7 +140,7 @@ def gen_esr(
             + mw_duration
             + readout_time
             + readout_and_repol_gap,
-            laserduration
+            laser_duration
             - readout_time,
             sequence_blocks=['wait_loop', 'block_0']
         )
@@ -100,6 +158,6 @@ def gen_esr(
     esr.sequencing_order = ['wait_loop', 'block_0']
     # This defines how often each block in the sequence gets repeated.
     esr.sequencing_repeats = [1, int(referenced_measurements/2) + 10]
-    esr.write()
+    esr.write(ps_step)
     # you can return a dict here that added / updates the configuration file.
     return {}


### PR DESCRIPTION
This PR adds support for sweeping pulse sequences in QuPyt. Instead of generating a single pulse sequence, measurements can now generate a series of pulse sequences and iterate over them during acquisition. Data saving has been updated accordingly by adding an additional dimension for the pulse-sequence step.
An updated ODMR example measurement and its corresponding pulse sequence are included to demonstrate this workflow. (A small typo fix is included but not central to the feature.)

**What changed**
Pulse sequence generation

- Pulse sequence writers can now generate and write multiple pulse sequences (counting upward by `ps_step`), which are then executed sequentially.

Measurement loop

- `run_measurement` now loops over PS steps and performs the configured averaging for each step.

Data container / saving

- Saved data now includes an extra dimension for the pulse-sequence index (`ps_step`), i.e. data is stored as:
- '[..., ps_step, dynamic_step, ...] '(exact ordering depends on averaging mode / reference channels, but `ps_step` is now explicitly represented).

Examples

- Updated ODMR example config + pulse sequence to showcase sweeping. It was written in a way that one can sweep any of the other pulse_sequence parameters

**Backwards compatibility**
The change is intended to be backwards compatible for running existing measurements:
  If no sweep is configured, the default remains effectively a single `ps_step`.

Important note for downstream analysis: saved datasets now have one additional dimension. Existing analysis scripts that assume the previous array shape may need minor adjustments (e.g., selecting ps_step=0 or iterating over the new axis).

**Testing**
Tested locally with the updated ODMR sweep example and a setup including an AWG, confirmed:

- Multiple pulse sequences are generated and executed in order.
- Data is saved with the new PS-step axis and expected shape.
- Legacy-style (single PS) behavior still works.
