### PR TITLE
Corrected save_in_chunk naming (+ some other small fixes)

### DIFF
--- a/qupyt/hardware/signal_sources.py
+++ b/qupyt/hardware/signal_sources.py
@@ -263,10 +263,9 @@ class PhaseMixin():
         channel, phase = phase
         phase_command = self.command.get(f"SetPhase{channel}")
         if phase_command is None:
-            raise ValueError(f"The configure signal source {repr(self)} currently does not implement setting a phase.") 
+            raise ValueError(f"The configured signal source {repr(self)} currently does not implement setting a phase.")
         self.instance.write(phase_command + str(phase))
         #self.opc_wait()
-        sleep(0.5)
         logging.info(
             f"{self.s_type} set phase channel {channel} to".ljust(65, ".")
             + f"{phase}"

--- a/qupyt/measurement_logic/data_handling.py
+++ b/qupyt/measurement_logic/data_handling.py
@@ -19,6 +19,7 @@ class Data(ConfigurationMixin):
         self.save_in_chunks: int = 0
         self.reference_channels: int = 2
         self.data: np.ndarray
+        self.filename: tuple[str, str]
         self.attribute_map = {
             "dynamic_steps": self._set_number_dynamic_steps,
             "ps_steps": self._set_number_pulse_sequences,
@@ -65,6 +66,12 @@ class Data(ConfigurationMixin):
 
     def _set_roi_shape(self, roi_shape: List[int]) -> None:
         self.roi_shape = roi_shape
+
+    def _set_filename(self, filename: tuple[str, str]) -> None:
+        self.filename = filename
+
+    def set_filename(self, filename: tuple[str, str]) -> None:
+        self._set_filename(filename)
 
     def set_dims_from_sensor(self, sensor: Sensor) -> None:
         self._set_ROI_from_sensor(sensor)
@@ -120,8 +127,10 @@ class Data(ConfigurationMixin):
 
     def update_data(self, data: np.ndarray, ps_step: int, dynamic_step: int, avg_step: int) -> None:
         if self.save_in_chunks != 0 and avg_step % self.save_in_chunks == 0:
-            self.save(f"save_chunk_{avg_step}.npy")
+            self._update_data_full(data, ps_step, dynamic_step)
+            self.save(self.filename[0] + "_ch-" +f"{avg_step}_" + self.filename[1])
             self.create_array()
+            return None
         if self.live_compression:
             self._update_data_compressed(data, ps_step, dynamic_step)
         else:

--- a/qupyt/measurement_logic/run_measurement.py
+++ b/qupyt/measurement_logic/run_measurement.py
@@ -35,6 +35,8 @@ def run_measurement(
         data_container = Data(params["data"])
         data_container.set_dims_from_sensor(sensor)
         data_container.create_array()
+        params["filename"] = params["experiment_type"] + "_" + mid
+        data_container.set_filename((params["experiment_type"],mid))
 
         for ps_itervalue in tqdm(range(ps_iterator_size)):
             synchroniser.open()
@@ -65,10 +67,10 @@ def run_measurement(
         sensor.close()
         synchroniser.close()
         print("sensor closed")
-        params["filename"] = params["experiment_type"] + "_" + mid
         params["measurement_status"] = return_status
         params["qupyt_version"] = qupyt_version
-
+        if data_container.save_in_chunks == 0:
+            data_container.save(params["filename"])
         data_container.save(params["filename"])
         with open(params["filename"] + ".yaml", "w", encoding="utf-8") as file:
             yaml.dump(params, file)

--- a/qupyt/pulse_sequences/SequenceDesigner.py
+++ b/qupyt/pulse_sequences/SequenceDesigner.py
@@ -239,7 +239,7 @@ class PulseBlasterSequence:
     def __init__(
         self,
         channel_mapping: Dict[str, Any],
-        yaml_file: Path = get_seq_dir() / "sequence.yaml",
+        yaml_file: Path = get_seq_dir() / "sequence_0.yaml",
     ) -> None:
         self.event_times: List[float] = []
         self.event_durations: List[float] = []


### PR DESCRIPTION
# Summary
This PR fixes the save_in_chunks naming of the files as well as some other small things:
1. Corrects naming and wiring for chunked data saves.
2. Fixes PulseBlaster’s default YAML sequence filename.
3. Removes unnecessary delay in phase-setting and fixes a typo in an error message.

# Changes
` qupyt/measurement_logic/data_handling.py`
    - Added filename state to Data and exposed `set_filename(...)`.
    - Updated `update_data(...)` chunk logic to:
        - persist current accumulated data before array reset,
        - save chunks using structured naming based on experiment id,
        - return early after chunk save/reset.
   
` qupyt/measurement_logic/run_measurement.py`
    - Sets params["filename"] earlier in the measurement flow.
    - Passes filename components into Data via `set_filename(experiment_type, mid)`.
    - Adds a non-chunk save guard before final save section.

 `qupyt/pulse_sequences/SequenceDesigner.py`
    - Fixed PulseBlaster default sequence file path from sequence.yaml to sequence_0.yaml.

 `qupyt/hardware/signal_sources.py`
    - Fixed typo in phase-setting ValueError message (“configure” → “configured”).
    - Removed an unnecessary sleep(0.5) in PhaseMixin.set_phase(...).