### PR TITLE
Child cycleAdd Tek AWG repeated-child upload mode for long CASR sequences

### DIFF
--- a/qupyt/hardware/sensors.py
+++ b/qupyt/hardware/sensors.py
@@ -1170,6 +1170,10 @@ class DAQ(Sensor):
         """
         See :meth:`Sensor.close`
         """
+        if not hasattr(self, "daq_task"):
+            # Setup can fail before DAQ.open() creates the task; close should not
+            # hide the original setup error with a secondary AttributeError.
+            return
         self.daq_task.close()
         logging.info("DAQ closed".ljust(65, "."))
 

--- a/qupyt/hardware/synchronisers.py
+++ b/qupyt/hardware/synchronisers.py
@@ -9,6 +9,7 @@ import logging
 import pickle
 from time import time
 from abc import ABC, abstractmethod
+from dataclasses import dataclass
 from typing import Any, Dict, Tuple, List, Union
 from pathlib import Path
 import sys
@@ -41,6 +42,23 @@ except (ImportError, NameError):
         "Could not load spinapi library".ljust(65, ".")
         + "[failed]\nIf you are not using a Pulse Streamer you do not need this!"
     )
+
+
+AWG_MAX_SEQUENCE_STEPS = 16_384
+AWG_MAX_STEP_REPEAT = 1_048_576
+
+
+@dataclass(frozen=True)
+class AWGSequenceStep:
+    """One expanded logical AWG sequencer step.
+
+    Repeated-child compression must compare all hardware-visible state, not just
+    waveform names; repeat counts and flag states are part of the timing contract.
+    """
+
+    waveform: str
+    repeat: int
+    flags: tuple[str, ...]
 
 
 class SynchroniserFactory:
@@ -193,6 +211,7 @@ class AWGenerator(VisaObject, Synchroniser):
         self.wavenames: list[str]
         self.seqrepeats: list[int]
         self.waveform_block: np.ndarray
+        self.sequence_options: Dict[str, Any] = {}
         self.analog_amplitude: float = 1.0
         self.marker_amplitude: float = 1.75
         self.dac_resolution: int = 12
@@ -207,6 +226,7 @@ class AWGenerator(VisaObject, Synchroniser):
             self._update_from_configuration(configuration)
         VisaObject.__init__(self, self.address, self.device_type)
         self.instance.timeout = 20000
+        self._limit_channels_to_available_outputs()
 
     def _extract_flags(self, channel_mapping: Dict[str, Union[int, str]]) -> list[str]:
         return [
@@ -216,6 +236,7 @@ class AWGenerator(VisaObject, Synchroniser):
         ]
 
     def open(self) -> None:
+        self._limit_channels_to_available_outputs()
         self._configure()
 
     def close(self) -> None:
@@ -238,14 +259,19 @@ class AWGenerator(VisaObject, Synchroniser):
         logging.info("Sent trigger to AWG".ljust(65, ".") + "[done]")
 
     def load_sequence(self, ps_yaml_file: str = "sequence_0.yaml") -> None:
+        self._limit_channels_to_available_outputs()
         self.stop()
+        self.instance.write("*CLS")
         self._clear_awg()
+        self.sequence_options = self._load_awg_sequence_options(ps_yaml_file)
         sequence_translator = PulseSequenceYaml(
             self.channel_mapping, self.channels, samprate=self.samprate, yaml_file = ps_yaml_file)
         sequence_translator.translate_yaml_to_numeric_instructions()
         self._load_sequence_block(get_seq_dir() / "sequence.npz")
         self._upload_waveforms()
+        self._raise_on_awg_errors("waveform upload")
         self._sequence("autoseq", nongatereps=1)
+        self._raise_on_awg_errors("sequencer construction")
         logging.info(
             "Loaded and sequenced current pulse sequence".ljust(
                 65, ".") + "[done]"
@@ -281,70 +307,344 @@ class AWGenerator(VisaObject, Synchroniser):
         self.opc_wait()
 
     def _sequence(self, seqname: str, nongatereps: int = 1) -> None:
+        mode = self._get_awg_sequence_mode()
+        logical_steps = self._get_logical_awg_steps()
+        if mode == "flat":
+            self._sequence_flat(seqname, logical_steps, nongatereps=nongatereps)
+            return
+        if mode == "repeated_child":
+            self._sequence_repeated_child(
+                seqname, logical_steps, nongatereps=nongatereps
+            )
+            return
+        raise ValueError(
+            f"Unsupported awg_sequence_mode: {mode!r}. Supported values are "
+            "'flat' and 'repeated_child'."
+        )
+
+    def _sequence_flat(
+        self, seqname: str, logical_steps: list[AWGSequenceStep], nongatereps: int = 1
+    ) -> None:
+        if len(logical_steps) > AWG_MAX_SEQUENCE_STEPS:
+            raise ValueError(
+                f"Expanded AWG sequence has {len(logical_steps)} steps, exceeding "
+                f"the AWG70000B limit of {AWG_MAX_SEQUENCE_STEPS}. Enable "
+                "awg_sequence_mode: repeated_child or reduce the sequence."
+        )
+        print(f"Tek AWG sequence mode: flat\nLogical steps: {len(logical_steps)}")
         print("Setting up sequencer".ljust(65, "."), end="")
-        for channel in self.channels:
-            self.instance.write(f'slist:sequence:delete "sub_{channel}"')
-            self.instance.write(
-                f'slist:sequence:new "sub_{channel}",{len(self.wavenames)},1'
-            )
-            self.instance.write(
-                f'slist:sequence:event:jtiming "sub_{channel}" immediate'
-            )
-            for i, wavename in enumerate(self.wavenames):
-                self.instance.write(
-                    f'slist:sequence:step{i+1}:rcount "sub_{channel}",{self.seqrepeats[i]}'
-                )
-                self.instance.write(
-                    f'slist:sequence:step{i+1}:tasset1:waveform "sub_{channel}","{wavename}_{channel}"'
+        # AWG70K sequence assets have one or more tracks. Each active AWG output
+        # is assigned one track of the same sequence asset via SOURCE:CASS.
+        tracks = len(self.channels)
+        self.instance.write(f'slist:sequence:delete "sub"')
+        self.instance.write(f'slist:sequence:new "sub",{len(logical_steps)},{tracks}')
+        self.instance.write(f'slist:sequence:event:jtiming "sub", immediate')
+        for i, step in enumerate(logical_steps, start=1):
+            for track, channel in enumerate(self.channels, start=1):
+                self._configure_waveform_step(
+                    "sub", i, step, channel, track, set_flags=(track == 1)
                 )
 
-                for flag_channel in self.flag_channels:
-                    if flag_channel in self.flag_values[wavename]:
-                        self.instance.write(
-                            f'slist:sequence:step{i+1}:tflag1:{flag_channel}flag "sub_{channel}",HIGH'
-                        )
-                    else:
-                        self.instance.write(
-                            f'slist:sequence:step{i+1}:tflag1:{flag_channel}flag "sub_{channel}",LOW'
-                        )
+        self.instance.write(f'slist:sequence:delete "{seqname}"')
+        self.instance.write(f'slist:sequence:new "{seqname}",2,{tracks}')
+        self.instance.write(f'slist:sequence:step2:goto "{seqname}",first')
+        self.instance.write(f'slist:sequence:event:jtiming "{seqname}", immediate')
 
-            self.instance.write(f'slist:sequence:delete "{seqname}_{channel}"')
+        # for gating pulse
+        self.instance.write(f'slist:sequence:step1:goto "{seqname}", first')
+        self.instance.write(f'slist:sequence:step1:ejinput "{seqname}", ATR')
+        self.instance.write(f'slist:sequence:step1:ejump "{seqname}", 2')
+        for track, channel in enumerate(self.channels, start=1):
             self.instance.write(
-                f'slist:sequence:new "{seqname}_{channel}",2,1')
-            self.instance.write(
-                f'slist:sequence:step2:goto "{seqname}_{channel}",first'
-            )
-            self.instance.write(
-                f'slist:sequence:event:jtiming "{seqname}_{channel}" immediate'
+                f'slist:sequence:step1:tasset{track}:waveform "{seqname}","{self.wavenames[0]}_{channel}"'
             )
 
-            # for gating pulse
-            self.instance.write(
-                f'slist:sequence:step1:goto "{seqname}_{channel}", first'
-            )
-            self.instance.write(
-                f'slist:sequence:step1:ejinput "{seqname}_{channel}", ATR'
-            )
-            self.instance.write(
-                f'slist:sequence:step1:ejump "{seqname}_{channel}", 2'
-            )
-            self.instance.write(
-                f'slist:sequence:step1:tasset1:waveform "{seqname}_{channel}","{self.wavenames[0]}_{channel}"'
-            )
+        # for actual seq
+        self.instance.write(
+            f'slist:sequence:step2:rcount "{seqname}", {nongatereps}'
+        )
+        for track in range(1, tracks + 1):
+            self.instance.write(f'SLIS:SEQ:STEP2:TASS{track}:SEQ "{seqname}","sub"')
 
-            # for actual seq
+        for track, channel in enumerate(self.channels, start=1):
             self.instance.write(
-                f'slist:sequence:step2:rcount "{seqname}_{channel}", {nongatereps}'
-            )
-            self.instance.write(
-                f'slist:sequence:step2:tasset1:sequence "{seqname}_{channel}","sub_{channel}"'
-            )
-
-            self.instance.write(
-                f'source{channel}:casset:sequence "{seqname}_{channel}",1'
+                f'SOURCE{channel}:CASS:SEQUENCE "{seqname}",{track}'
             )
         self.opc_wait()
         print(colored(" [done]", "green"))
+
+    def _sequence_repeated_child(
+        self, seqname: str, logical_steps: list[AWGSequenceStep], nongatereps: int = 1
+    ) -> None:
+        prefix, child, repetitions, suffix = self._validate_repeated_child_region(
+            logical_steps
+        )
+        compact_body_steps = len(prefix) + 1 + len(suffix)
+        top_level_steps = 1 + compact_body_steps
+        print(
+            "Tek AWG sequence mode: repeated_child\n"
+            f"Expanded logical steps: {len(logical_steps)}\n"
+            f"Prefix steps: {len(prefix)}\n"
+            f"Child steps: {len(child)}\n"
+            f"Child repetitions: {repetitions}\n"
+            f"Suffix steps: {len(suffix)}\n"
+            f"Compact measurement steps: {compact_body_steps}\n"
+            f"Top-level steps: {top_level_steps}\n"
+            f"Unique waveforms: {len(set(self.wavenames))}"
+        )
+        print("Setting up sequencer".ljust(65, "."), end="")
+        # Keep waveform memory unchanged: the child is a sequence asset that
+        # references already-uploaded waveforms, not a concatenated waveform.
+        tracks = len(self.channels)
+        child_sequence = "child"
+        top_sequence = seqname
+
+        self.instance.write(f'slist:sequence:delete "{child_sequence}"')
+        self.instance.write(
+            f'slist:sequence:new "{child_sequence}",{len(child)},{tracks}'
+        )
+        self.instance.write(
+            f'slist:sequence:event:jtiming "{child_sequence}", immediate'
+        )
+        for step_index, step in enumerate(child, start=1):
+            for track, channel in enumerate(self.channels, start=1):
+                self._configure_waveform_step(
+                    child_sequence,
+                    step_index,
+                    step,
+                    channel,
+                    track,
+                    set_flags=(track == 1),
+                )
+
+        self.instance.write(f'slist:sequence:delete "{top_sequence}"')
+        self.instance.write(
+            f'slist:sequence:new "{top_sequence}",{top_level_steps},{tracks}'
+        )
+        self.instance.write(
+            f'slist:sequence:event:jtiming "{top_sequence}", immediate'
+        )
+        self.instance.write(f'slist:sequence:step1:goto "{top_sequence}", first')
+        self.instance.write(f'slist:sequence:step1:ejinput "{top_sequence}", ATR')
+        self.instance.write(f'slist:sequence:step1:ejump "{top_sequence}", 2')
+        for track, channel in enumerate(self.channels, start=1):
+            self.instance.write(
+                f'slist:sequence:step1:tasset{track}:waveform "{top_sequence}","{self.wavenames[0]}_{channel}"'
+            )
+
+        body_step = 2
+        # The top-level sequence preserves the existing trigger-wait step and
+        # then runs prefix + repeated child + suffix directly. Avoiding
+        # wrapper -> body -> child nesting keeps this compatible with AWG70000B.
+        for step in prefix:
+            for track, channel in enumerate(self.channels, start=1):
+                self._configure_waveform_step(
+                    top_sequence, body_step, step, channel, track, set_flags=(track == 1)
+                )
+            body_step += 1
+        self.instance.write(
+            f'slist:sequence:step{body_step}:rcount "{top_sequence}",{repetitions}'
+        )
+        for track in range(1, tracks + 1):
+            self.instance.write(
+                f'SLIS:SEQ:STEP{body_step}:TASS{track}:SEQ "{top_sequence}","{child_sequence}"'
+            )
+        body_step += 1
+        for step in suffix:
+            for track, channel in enumerate(self.channels, start=1):
+                self._configure_waveform_step(
+                    top_sequence, body_step, step, channel, track, set_flags=(track == 1)
+                )
+            body_step += 1
+        self.instance.write(
+            f'slist:sequence:step{top_level_steps}:goto "{top_sequence}", first'
+        )
+        for track, channel in enumerate(self.channels, start=1):
+            self.instance.write(
+                f'SOURCE{channel}:CASS:SEQUENCE "{top_sequence}",{track}'
+            )
+        self.opc_wait()
+        print(colored(" [done]", "green"))
+
+    def _configure_waveform_step(
+        self,
+        sequence_name: str,
+        step_number: int,
+        step: AWGSequenceStep,
+        channel: int,
+        track: int,
+        set_flags: bool = True,
+    ) -> None:
+        self.instance.write(
+            f'slist:sequence:step{step_number}:rcount "{sequence_name}",{step.repeat}'
+        )
+        self.instance.write(
+            f'slist:sequence:step{step_number}:tasset{track}:waveform "{sequence_name}","{step.waveform}_{channel}"'
+        )
+        if not set_flags:
+            return
+        for flag_channel in self.flag_channels:
+            flag_value = "HIGH" if flag_channel in step.flags else "LOW"
+            self.instance.write(
+                f'slist:sequence:step{step_number}:tflag1:{flag_channel}flag "{sequence_name}",{flag_value}'
+            )
+
+    def _get_awg_sequence_mode(self) -> str:
+        return str(self.sequence_options.get("awg_sequence_mode", "flat"))
+
+    def _get_logical_awg_steps(self) -> list[AWGSequenceStep]:
+        if len(self.wavenames) != len(self.seqrepeats):
+            raise ValueError(
+                "Tek AWG sequence metadata mismatch: "
+                f"{len(self.wavenames)} waveform names but "
+                f"{len(self.seqrepeats)} repeat counts."
+            )
+        steps = []
+        for wavename, repeat in zip(self.wavenames, self.seqrepeats):
+            repeat = int(repeat)
+            self._validate_awg_repeat_count(repeat, f"step {len(steps) + 1}")
+            steps.append(
+                AWGSequenceStep(
+                    waveform=str(wavename),
+                    repeat=repeat,
+                    flags=tuple(sorted(self.flag_values.get(wavename, []))),
+                )
+            )
+        return steps
+
+    def _validate_awg_repeat_count(self, repeat: int, context: str) -> None:
+        if repeat <= 0:
+            raise ValueError(f"Tek AWG {context} repeat count must be positive.")
+        if repeat > AWG_MAX_STEP_REPEAT:
+            raise ValueError(
+                f"Tek AWG {context} repeat count {repeat} exceeds the "
+                f"AWG70000B limit of {AWG_MAX_STEP_REPEAT}."
+            )
+
+    def _validate_repeated_child_region(
+        self, steps: list[AWGSequenceStep]
+    ) -> tuple[list[AWGSequenceStep], list[AWGSequenceStep], int, list[AWGSequenceStep]]:
+        config = self.sequence_options.get("awg_repeated_child", {})
+        if not isinstance(config, dict):
+            raise ValueError(
+                "awg_repeated_child must be a mapping with prefix_steps, "
+                "child_steps, and optionally repetitions."
+            )
+        try:
+            prefix_steps = int(config.get("prefix_steps", 0))
+            child_steps = int(config["child_steps"])
+        except KeyError as exc:
+            raise ValueError(
+                "awg_repeated_child requires child_steps for repeated_child mode."
+            ) from exc
+        repetitions_config = config.get("repetitions")
+        if prefix_steps < 0:
+            raise ValueError(
+                f"awg_repeated_child prefix_steps must be >= 0, got {prefix_steps}."
+            )
+        if child_steps <= 0:
+            raise ValueError(
+                f"awg_repeated_child child_steps must be > 0, got {child_steps}."
+            )
+        if child_steps > AWG_MAX_SEQUENCE_STEPS:
+            raise ValueError(
+                f"Repeated child sequence has {child_steps} steps, exceeding "
+                f"the AWG70000B limit of {AWG_MAX_SEQUENCE_STEPS}."
+            )
+        if prefix_steps + child_steps > len(steps):
+            raise ValueError(
+                "awg_repeated_child prefix_steps + child_steps exceeds the "
+                f"logical sequence length: {prefix_steps} + {child_steps} > "
+                f"{len(steps)}."
+            )
+        child = steps[prefix_steps : prefix_steps + child_steps]
+        if repetitions_config is None:
+            repetitions = self._infer_child_repetitions(steps, prefix_steps, child)
+        else:
+            repetitions = int(repetitions_config)
+            if repetitions <= 0:
+                raise ValueError(
+                    "awg_repeated_child repetitions must be > 0, got "
+                    f"{repetitions}."
+                )
+            expected_end = prefix_steps + repetitions * child_steps
+            if expected_end > len(steps):
+                raise ValueError(
+                    "awg_repeated_child prefix_steps + repetitions * child_steps "
+                    "exceeds the logical sequence length: "
+                    f"{prefix_steps} + {repetitions} * {child_steps} = "
+                    f"{expected_end} > {len(steps)}."
+                )
+            for repetition_index in range(repetitions):
+                start = prefix_steps + repetition_index * child_steps
+                current_child = steps[start : start + child_steps]
+                if current_child != child:
+                    raise ValueError(
+                        "Repeated child block mismatch at repetition "
+                        f"{repetition_index + 1}. Waveform names, repeat counts, "
+                        "and flags must match exactly for repeated_child mode."
+                    )
+        self._validate_awg_repeat_count(repetitions, "child-sequence parent")
+        suffix_start = prefix_steps + repetitions * child_steps
+        suffix = steps[suffix_start:]
+        compact_body_steps = prefix_steps + 1 + len(suffix)
+        if compact_body_steps > AWG_MAX_SEQUENCE_STEPS:
+            raise ValueError(
+                f"Compact AWG parent/body sequence has {compact_body_steps} steps, "
+                f"exceeding the AWG70000B limit of {AWG_MAX_SEQUENCE_STEPS}."
+            )
+        return steps[:prefix_steps], child, repetitions, suffix
+
+    def _infer_child_repetitions(
+        self, steps: list[AWGSequenceStep], prefix_steps: int, child: list[AWGSequenceStep]
+    ) -> int:
+        child_steps = len(child)
+        repetitions = 0
+        start = prefix_steps
+        while steps[start : start + child_steps] == child:
+            repetitions += 1
+            start += child_steps
+        if repetitions < 2:
+            raise ValueError(
+                "Could not infer awg_repeated_child repetitions: at least two "
+                "identical child occurrences are required."
+            )
+        return repetitions
+
+    def _load_awg_sequence_options(self, ps_yaml_file: Path) -> Dict[str, Any]:
+        yaml_file = Path(ps_yaml_file)
+        if not yaml_file.is_absolute():
+            yaml_file = get_seq_dir() / yaml_file
+        with open(yaml_file, "r", encoding="utf-8") as file:
+            sequence_instructions = yaml.safe_load(file)
+        return {
+            key: sequence_instructions[key]
+            for key in ("awg_sequence_mode", "awg_repeated_child")
+            if key in sequence_instructions
+        }
+
+    def _read_awg_errors(self) -> list[str]:
+        errors = []
+        while True:
+            response = str(self.instance.query("SYSTEM:ERROR?")).strip()
+            code_text, _, message = response.partition(",")
+            try:
+                code = int(code_text)
+            except ValueError:
+                errors.append(response)
+                break
+            if code == 0:
+                break
+            errors.append(f"{code},{message}".rstrip(","))
+        return errors
+
+    def _raise_on_awg_errors(self, context: str) -> None:
+        errors = self._read_awg_errors()
+        if errors:
+            raise RuntimeError(
+                f"Tektronix AWG reported errors during {context}: "
+                + "; ".join(errors)
+            )
 
     def _load_sequence_block(self, seqname: Path) -> None:
         block = np.load(seqname)
@@ -432,6 +732,21 @@ class AWGenerator(VisaObject, Synchroniser):
 
     def _set_channels_attribute(self, channels: list[int]) -> None:
         self.channels = channels
+
+    def _limit_channels_to_available_outputs(self) -> None:
+        try:
+            identity = str(self.instance.query("*IDN?"))
+        except Exception:
+            return
+        if "AWG70001" in identity and self.channels != [1]:
+            # AWG70001B is a single-output model. Sending SOURCE2 commands raises
+            # SCPI header errors, so restrict waveform generation/upload as well
+            # as sequence assignment to the available output.
+            print("Detected single-channel Tektronix AWG70001; using channel 1 only.")
+            logging.warning(
+                "Detected single-channel Tektronix AWG70001; using channel 1 only."
+            )
+            self.channels = [1]
 
     def plot_waveform(self, wavename: str) -> None:
         """

--- a/qupyt/hardware/synchronisers.py
+++ b/qupyt/hardware/synchronisers.py
@@ -44,6 +44,9 @@ except (ImportError, NameError):
     )
 
 
+# Default AWG70000B sequencer limits. AWG/Mock synchroniser configs can
+# override these with awg_max_sequence_steps / awg_max_step_repeat for other
+# AWG models; pulse-sequence YAML should not define hardware limits.
 AWG_MAX_SEQUENCE_STEPS = 16_384
 AWG_MAX_STEP_REPEAT = 1_048_576
 
@@ -59,6 +62,54 @@ class AWGSequenceStep:
     waveform: str
     repeat: int
     flags: tuple[str, ...]
+
+
+def _check_awg_sequence_mode_supported(
+    sequence_instructions: Dict[str, Any],
+    device_type: str,
+    supported_modes: tuple[str, ...],
+) -> str:
+    """Validate optional Tek AWG upload metadata for a synchroniser.
+
+    awg_sequence_mode is not part of the logical pulse program. It only
+    describes how TekAWG should upload that pulse program. Non-AWG devices
+    reject unsupported modes explicitly so a Tek-only YAML option is not
+    silently ignored.
+    """
+
+    mode = str(sequence_instructions.get("awg_sequence_mode", "flat"))
+    if mode not in supported_modes:
+        message = (
+            f"awg_sequence_mode: {mode} is not supported by {device_type}. "
+            f"Supported modes for {device_type}: {', '.join(supported_modes)}."
+        )
+        logging.error(message)
+        raise ValueError(message)
+    logging.info(
+        "%s accepted awg_sequence_mode=%s", device_type, mode
+    )
+    return mode
+
+
+def _validate_awg_limit(value: Any, key: str, device_type: str) -> int:
+    """Validate an AWG hardware limit from synchroniser.config.
+
+    Defaults are assigned in the synchroniser __init__; this helper is only
+    called when the YAML provides an override for another AWG model.
+    """
+
+    try:
+        limit = int(value)
+    except (TypeError, ValueError) as exc:
+        raise ValueError(
+            f"{key} must be an integer AWG limit for {device_type}, got {value!r}."
+        ) from exc
+    if limit <= 0:
+        raise ValueError(
+            f"{key} must be a positive AWG limit for {device_type}, got {limit}."
+        )
+    logging.info("%s configured %s=%s", device_type, key, limit)
+    return limit
 
 
 class SynchroniserFactory:
@@ -197,7 +248,10 @@ class Synchroniser(ABC, ConfigurationMixin):
 
 class AWGenerator(VisaObject, Synchroniser):
     """
-    Synchroniser implementation for the Tektronix AWG 5000 series.
+    Synchroniser implementation for Tektronix AWGs.
+
+    Flat mode preserves the existing Tek AWG behavior. repeated_child mode uses
+    Tek AWG70000-series sequence-asset SCPI and was tested on AWG70001B.
     """
 
     def __init__(
@@ -217,11 +271,17 @@ class AWGenerator(VisaObject, Synchroniser):
         self.dac_resolution: int = 12
         self.channels: list[int] = [1, 2]
         self.marker_channels: list[int] = [1, 2, 3, 4]
+        self.awg_max_sequence_steps: int = AWG_MAX_SEQUENCE_STEPS
+        self.awg_max_step_repeat: int = AWG_MAX_STEP_REPEAT
 
         Synchroniser.__init__(self)
         self.attribute_map["device_type"] = self._set_device_type
         self.attribute_map["sampling_rate"] = self._set_sampling_rate_attribute
         self.attribute_map["channels"] = self._set_channels_attribute
+        self.attribute_map["awg_max_sequence_steps"] = (
+            self._set_awg_max_sequence_steps
+        )
+        self.attribute_map["awg_max_step_repeat"] = self._set_awg_max_step_repeat
         if configuration is not None:
             self._update_from_configuration(configuration)
         VisaObject.__init__(self, self.address, self.device_type)
@@ -313,6 +373,7 @@ class AWGenerator(VisaObject, Synchroniser):
             self._sequence_flat(seqname, logical_steps, nongatereps=nongatereps)
             return
         if mode == "repeated_child":
+            self._raise_if_repeated_child_is_unverified_model()
             self._sequence_repeated_child(
                 seqname, logical_steps, nongatereps=nongatereps
             )
@@ -325,13 +386,15 @@ class AWGenerator(VisaObject, Synchroniser):
     def _sequence_flat(
         self, seqname: str, logical_steps: list[AWGSequenceStep], nongatereps: int = 1
     ) -> None:
-        if len(logical_steps) > AWG_MAX_SEQUENCE_STEPS:
+        if len(logical_steps) > self.awg_max_sequence_steps:
             raise ValueError(
                 f"Expanded AWG sequence has {len(logical_steps)} steps, exceeding "
-                f"the AWG70000B limit of {AWG_MAX_SEQUENCE_STEPS}. Enable "
+                f"the configured AWG limit of {self.awg_max_sequence_steps}. Enable "
                 "awg_sequence_mode: repeated_child or reduce the sequence."
         )
-        print(f"Tek AWG sequence mode: flat\nLogical steps: {len(logical_steps)}")
+        summary = f"Tek AWG sequence mode: flat\nLogical steps: {len(logical_steps)}"
+        print(summary)
+        logging.info("Tek AWG sequence mode: flat; logical_steps=%s", len(logical_steps))
         print("Setting up sequencer".ljust(65, "."), end="")
         # AWG70K sequence assets have one or more tracks. Each active AWG output
         # is assigned one track of the same sequence asset via SOURCE:CASS.
@@ -376,12 +439,15 @@ class AWGenerator(VisaObject, Synchroniser):
     def _sequence_repeated_child(
         self, seqname: str, logical_steps: list[AWGSequenceStep], nongatereps: int = 1
     ) -> None:
+        # This parent/child sequencer upload uses Tek AWG70000-series SCPI and
+        # was tested on TEKTRONIX AWG70001B firmware FV:8.1.0266.0. Similar Tek
+        # models should be verified before enabling repeated_child in the lab.
         prefix, child, repetitions, suffix = self._validate_repeated_child_region(
             logical_steps
         )
         compact_body_steps = len(prefix) + 1 + len(suffix)
         top_level_steps = 1 + compact_body_steps
-        print(
+        summary = (
             "Tek AWG sequence mode: repeated_child\n"
             f"Expanded logical steps: {len(logical_steps)}\n"
             f"Prefix steps: {len(prefix)}\n"
@@ -391,6 +457,21 @@ class AWGenerator(VisaObject, Synchroniser):
             f"Compact measurement steps: {compact_body_steps}\n"
             f"Top-level steps: {top_level_steps}\n"
             f"Unique waveforms: {len(set(self.wavenames))}"
+        )
+        print(summary)
+        logging.info(
+            "Tek AWG sequence mode: repeated_child; expanded_logical_steps=%s; "
+            "prefix_steps=%s; child_steps=%s; child_repetitions=%s; "
+            "suffix_steps=%s; compact_measurement_steps=%s; top_level_steps=%s; "
+            "unique_waveforms=%s",
+            len(logical_steps),
+            len(prefix),
+            len(child),
+            repetitions,
+            len(suffix),
+            compact_body_steps,
+            top_level_steps,
+            len(set(self.wavenames)),
         )
         print("Setting up sequencer".ljust(65, "."), end="")
         # Keep waveform memory unchanged: the child is a sequence asset that
@@ -515,10 +596,10 @@ class AWGenerator(VisaObject, Synchroniser):
     def _validate_awg_repeat_count(self, repeat: int, context: str) -> None:
         if repeat <= 0:
             raise ValueError(f"Tek AWG {context} repeat count must be positive.")
-        if repeat > AWG_MAX_STEP_REPEAT:
+        if repeat > self.awg_max_step_repeat:
             raise ValueError(
                 f"Tek AWG {context} repeat count {repeat} exceeds the "
-                f"AWG70000B limit of {AWG_MAX_STEP_REPEAT}."
+                f"configured AWG limit of {self.awg_max_step_repeat}."
             )
 
     def _validate_repeated_child_region(
@@ -546,10 +627,10 @@ class AWGenerator(VisaObject, Synchroniser):
             raise ValueError(
                 f"awg_repeated_child child_steps must be > 0, got {child_steps}."
             )
-        if child_steps > AWG_MAX_SEQUENCE_STEPS:
+        if child_steps > self.awg_max_sequence_steps:
             raise ValueError(
                 f"Repeated child sequence has {child_steps} steps, exceeding "
-                f"the AWG70000B limit of {AWG_MAX_SEQUENCE_STEPS}."
+                f"the configured AWG limit of {self.awg_max_sequence_steps}."
             )
         if prefix_steps + child_steps > len(steps):
             raise ValueError(
@@ -569,11 +650,19 @@ class AWGenerator(VisaObject, Synchroniser):
                 )
             expected_end = prefix_steps + repetitions * child_steps
             if expected_end > len(steps):
+                available_steps = len(steps) - prefix_steps
+                max_complete_repetitions = available_steps // child_steps
                 raise ValueError(
-                    "awg_repeated_child prefix_steps + repetitions * child_steps "
-                    "exceeds the logical sequence length: "
+                    "awg_repeated_child does not match the expanded logical "
+                    "sequence. The configured repeated region would end after "
                     f"{prefix_steps} + {repetitions} * {child_steps} = "
-                    f"{expected_end} > {len(steps)}."
+                    f"{expected_end} steps, but the generated sequence has only "
+                    f"{len(steps)} steps. After the {prefix_steps} prefix steps, "
+                    f"only {available_steps} steps remain, which can contain at "
+                    f"most {max_complete_repetitions} complete child repetitions "
+                    f"of {child_steps} steps. Check that n_meas/repetitions and "
+                    "len(cycle_order)/child_steps are calculated from the same "
+                    "sequence that is written to sequencing_order."
                 )
             for repetition_index in range(repetitions):
                 start = prefix_steps + repetition_index * child_steps
@@ -588,10 +677,10 @@ class AWGenerator(VisaObject, Synchroniser):
         suffix_start = prefix_steps + repetitions * child_steps
         suffix = steps[suffix_start:]
         compact_body_steps = prefix_steps + 1 + len(suffix)
-        if compact_body_steps > AWG_MAX_SEQUENCE_STEPS:
+        if compact_body_steps > self.awg_max_sequence_steps:
             raise ValueError(
                 f"Compact AWG parent/body sequence has {compact_body_steps} steps, "
-                f"exceeding the AWG70000B limit of {AWG_MAX_SEQUENCE_STEPS}."
+                f"exceeding the configured AWG limit of {self.awg_max_sequence_steps}."
             )
         return steps[:prefix_steps], child, repetitions, suffix
 
@@ -733,20 +822,82 @@ class AWGenerator(VisaObject, Synchroniser):
     def _set_channels_attribute(self, channels: list[int]) -> None:
         self.channels = channels
 
+    def _set_awg_max_sequence_steps(self, max_sequence_steps: int) -> None:
+        self.awg_max_sequence_steps = _validate_awg_limit(
+            max_sequence_steps,
+            "awg_max_sequence_steps",
+            "Tek AWG",
+        )
+
+    def _set_awg_max_step_repeat(self, max_step_repeat: int) -> None:
+        self.awg_max_step_repeat = _validate_awg_limit(
+            max_step_repeat,
+            "awg_max_step_repeat",
+            "Tek AWG",
+        )
+
     def _limit_channels_to_available_outputs(self) -> None:
         try:
-            identity = str(self.instance.query("*IDN?"))
+            identity = self._query_awg_identity()
         except Exception:
             return
-        if "AWG70001" in identity and self.channels != [1]:
-            # AWG70001B is a single-output model. Sending SOURCE2 commands raises
-            # SCPI header errors, so restrict waveform generation/upload as well
-            # as sequence assignment to the available output.
-            print("Detected single-channel Tektronix AWG70001; using channel 1 only.")
-            logging.warning(
-                "Detected single-channel Tektronix AWG70001; using channel 1 only."
+        available_channels = self._detect_awg70000_available_channels(identity)
+        if available_channels is None:
+            return
+        usable_channels = [
+            channel for channel in self.channels if channel in available_channels
+        ]
+        if not usable_channels:
+            raise ValueError(
+                "Configured Tek AWG channels do not match the detected "
+                f"AWG70000-series outputs. channels={self.channels}, "
+                f"available_channels={available_channels}, idn={identity.strip()!r}."
             )
-            self.channels = [1]
+        if usable_channels != self.channels:
+            message = (
+                "Restricting Tek AWG channels to detected AWG70000-series "
+                f"outputs: requested {self.channels}, available "
+                f"{available_channels}, using {usable_channels}, "
+                f"idn={identity.strip()!r}."
+            )
+            print(message)
+            logging.warning(message)
+            self.channels = usable_channels
+
+    def _detect_awg70000_available_channels(self, identity: str) -> list[int] | None:
+        """Return available output channels for known Tek AWG70000-series models.
+
+        The AWG70001 is single-output, while AWG70002 models have two outputs.
+        For unknown models, return None and leave the user-configured channels
+        unchanged instead of guessing hardware capabilities.
+        """
+
+        if "AWG70001" in identity:
+            return [1]
+        if "AWG70002" in identity:
+            return [1, 2]
+        return None
+
+    def _query_awg_identity(self) -> str:
+        return str(self.instance.query("*IDN?"))
+
+    def _raise_if_repeated_child_is_unverified_model(self) -> None:
+        try:
+            identity = self._query_awg_identity()
+        except Exception:
+            return
+        if "AWG5202" in identity:
+            message = (
+                "awg_sequence_mode: repeated_child is not enabled for detected "
+                f"AWG model {identity.strip()!r}. The current repeated_child "
+                "SCPI path was tested on TEKTRONIX AWG70001B and uses "
+                "AWG70000-series sequence asset/track commands. AWG5202 may be "
+                "similar, but it must be verified with the programming manual "
+                "or a hardware test before this guard is removed. Use flat mode "
+                "on AWG5202 for now."
+            )
+            logging.error(message)
+            raise ValueError(message)
 
     def plot_waveform(self, wavename: str) -> None:
         """
@@ -1013,6 +1164,11 @@ class PStreamer(Synchroniser):
             self.yaml_file = set_up.get_seq_dir() / ps_yaml_file
             with open(self.yaml_file, "r", encoding="utf-8") as file:
                 full_pulse_list = yaml.load(file, Loader=yaml.FullLoader)
+            # PulseStreamer consumes the expanded pulse program directly; it
+            # does not implement Tek AWG parent/child sequencer compression.
+            _check_awg_sequence_mode_supported(
+                full_pulse_list, "PulseStreamer", ("flat",)
+            )
             sequence_order = full_pulse_list["sequencing_order"]
             sequencing_repeats = full_pulse_list["sequencing_repeats"]
 
@@ -1113,8 +1269,14 @@ class MockGenerator(Synchroniser):
     def __init__(self, configuration: Dict[str, Any], channel_mapping: Dict[str, Any]):
         self.channel_mapping = channel_mapping
         self.device_type: str = "MockGenerator"
+        self.awg_max_sequence_steps: int = AWG_MAX_SEQUENCE_STEPS
+        self.awg_max_step_repeat: int = AWG_MAX_STEP_REPEAT
 
         Synchroniser.__init__(self)
+        self.attribute_map["awg_max_sequence_steps"] = (
+            self._set_awg_max_sequence_steps
+        )
+        self.attribute_map["awg_max_step_repeat"] = self._set_awg_max_step_repeat
         self.initial_configuration_dict = configuration
         if configuration is not None:
             self._update_from_configuration(configuration)
@@ -1138,8 +1300,17 @@ class MockGenerator(Synchroniser):
             total_duration = (
                 float(full_pulse_list["total_duration"]) * 1e3
             )  # convert to ns
-            _ = full_pulse_list["sequencing_order"]
-            _ = full_pulse_list["sequencing_repeats"]
+            sequence_order = full_pulse_list["sequencing_order"]
+            sequencing_repeats = full_pulse_list["sequencing_repeats"]
+            # Mock accepts repeated_child as a dry run of the Tek AWG upload
+            # strategy. It validates the metadata but still has no hardware
+            # sequencer to program.
+            _check_awg_sequence_mode_supported(
+                full_pulse_list, "MockSynchroniser", ("flat", "repeated_child")
+            )
+            self._validate_awg_sequence_options(
+                full_pulse_list, sequence_order, sequencing_repeats
+            )
             if total_duration - round(total_duration) != 0:
                 logging.warning(
                     "Warning: The total duration is not multiple of the sampling time and is being rounded!"
@@ -1157,6 +1328,199 @@ class MockGenerator(Synchroniser):
             logging.exception(
                 "Caught attribute error when writing loading from yaml pulse sequence"
             )
+
+    def _validate_awg_sequence_options(
+        self,
+        full_pulse_list: Dict[str, Any],
+        sequence_order: List[str],
+        sequencing_repeats: List[int],
+    ) -> None:
+        """Dry-run TekAWG sequence-mode metadata for mock measurements.
+
+        The mock does not send SCPI commands or compress waveforms. It checks
+        that the expanded logical sequence can be represented by the configured
+        repeated_child parent/child layout, so mock measurements catch the same
+        configuration mistakes before the YAML is sent to a real AWG.
+        """
+
+        mode = str(full_pulse_list.get("awg_sequence_mode", "flat"))
+        if mode == "flat":
+            logging.info("MockSynchroniser AWG sequence mode: flat")
+            return
+        if mode != "repeated_child":
+            raise ValueError(
+                f"Unsupported awg_sequence_mode for MockSynchroniser: {mode!r}. "
+                "Supported values are 'flat' and 'repeated_child'."
+            )
+
+        if len(sequence_order) != len(sequencing_repeats):
+            raise ValueError(
+                "MockSynchroniser sequence metadata mismatch: "
+                f"{len(sequence_order)} sequence entries but "
+                f"{len(sequencing_repeats)} repeat counts."
+            )
+
+        previous_options = getattr(self, "sequence_options", {})
+        self.sequence_options = {
+            key: full_pulse_list[key]
+            for key in ("awg_sequence_mode", "awg_repeated_child")
+            if key in full_pulse_list
+        }
+        try:
+            logical_steps = []
+            for block, repeat in zip(sequence_order, sequencing_repeats):
+                repeat = int(repeat)
+                self._validate_awg_repeat_count(repeat, f"step {len(logical_steps) + 1}")
+                logical_steps.append(AWGSequenceStep(str(block), repeat, ()))
+            prefix, child, repetitions, suffix = self._validate_repeated_child_region(
+                logical_steps
+            )
+        finally:
+            self.sequence_options = previous_options
+
+        summary = (
+            "MockSynchroniser AWG sequence mode: repeated_child\n"
+            f"Expanded logical steps: {len(logical_steps)}\n"
+            f"Prefix steps: {len(prefix)}\n"
+            f"Child steps: {len(child)}\n"
+            f"Child repetitions: {repetitions}\n"
+            f"Suffix steps: {len(suffix)}"
+        )
+        print(summary)
+        logging.info(
+            "MockSynchroniser AWG sequence mode: repeated_child; "
+            "expanded_logical_steps=%s; prefix_steps=%s; child_steps=%s; "
+            "child_repetitions=%s; suffix_steps=%s",
+            len(logical_steps),
+            len(prefix),
+            len(child),
+            repetitions,
+            len(suffix),
+        )
+
+    def _validate_awg_repeat_count(self, repeat: int, context: str) -> None:
+        if repeat <= 0:
+            raise ValueError(f"MockSynchroniser AWG {context} repeat count must be positive.")
+        if repeat > self.awg_max_step_repeat:
+            raise ValueError(
+                f"MockSynchroniser AWG {context} repeat count {repeat} exceeds "
+                f"the configured AWG limit of {self.awg_max_step_repeat}."
+            )
+
+    def _set_awg_max_sequence_steps(self, max_sequence_steps: int) -> None:
+        self.awg_max_sequence_steps = _validate_awg_limit(
+            max_sequence_steps,
+            "awg_max_sequence_steps",
+            "MockSynchroniser",
+        )
+
+    def _set_awg_max_step_repeat(self, max_step_repeat: int) -> None:
+        self.awg_max_step_repeat = _validate_awg_limit(
+            max_step_repeat,
+            "awg_max_step_repeat",
+            "MockSynchroniser",
+        )
+
+    def _validate_repeated_child_region(
+        self, steps: list[AWGSequenceStep]
+    ) -> tuple[list[AWGSequenceStep], list[AWGSequenceStep], int, list[AWGSequenceStep]]:
+        config = self.sequence_options.get("awg_repeated_child", {})
+        if not isinstance(config, dict):
+            raise ValueError(
+                "awg_repeated_child must be a mapping with prefix_steps, "
+                "child_steps, and optionally repetitions."
+            )
+        try:
+            prefix_steps = int(config.get("prefix_steps", 0))
+            child_steps = int(config["child_steps"])
+        except KeyError as exc:
+            raise ValueError(
+                "awg_repeated_child requires child_steps for repeated_child mode."
+            ) from exc
+
+        repetitions_config = config.get("repetitions")
+        if prefix_steps < 0:
+            raise ValueError(
+                f"awg_repeated_child prefix_steps must be >= 0, got {prefix_steps}."
+            )
+        if child_steps <= 0:
+            raise ValueError(
+                f"awg_repeated_child child_steps must be > 0, got {child_steps}."
+            )
+        if child_steps > self.awg_max_sequence_steps:
+            raise ValueError(
+                f"Repeated child sequence has {child_steps} steps, exceeding "
+                f"the configured AWG limit of {self.awg_max_sequence_steps}."
+            )
+        if prefix_steps + child_steps > len(steps):
+            raise ValueError(
+                "awg_repeated_child prefix_steps + child_steps exceeds the "
+                f"logical sequence length: {prefix_steps} + {child_steps} > "
+                f"{len(steps)}."
+            )
+
+        child = steps[prefix_steps : prefix_steps + child_steps]
+        if repetitions_config is None:
+            repetitions = self._infer_child_repetitions(steps, prefix_steps, child)
+        else:
+            repetitions = int(repetitions_config)
+            if repetitions <= 0:
+                raise ValueError(
+                    "awg_repeated_child repetitions must be > 0, got "
+                    f"{repetitions}."
+                )
+            expected_end = prefix_steps + repetitions * child_steps
+            if expected_end > len(steps):
+                available_steps = len(steps) - prefix_steps
+                max_complete_repetitions = available_steps // child_steps
+                raise ValueError(
+                    "awg_repeated_child does not match the expanded logical "
+                    "sequence. The configured repeated region would end after "
+                    f"{prefix_steps} + {repetitions} * {child_steps} = "
+                    f"{expected_end} steps, but the generated sequence has only "
+                    f"{len(steps)} steps. After the {prefix_steps} prefix steps, "
+                    f"only {available_steps} steps remain, which can contain at "
+                    f"most {max_complete_repetitions} complete child repetitions "
+                    f"of {child_steps} steps. Check that n_meas/repetitions and "
+                    "len(cycle_order)/child_steps are calculated from the same "
+                    "sequence that is written to sequencing_order."
+                )
+            for repetition_index in range(repetitions):
+                start = prefix_steps + repetition_index * child_steps
+                current_child = steps[start : start + child_steps]
+                if current_child != child:
+                    raise ValueError(
+                        "Repeated child block mismatch at repetition "
+                        f"{repetition_index + 1}. Sequence names and repeat "
+                        "counts must match exactly for repeated_child mode."
+                    )
+
+        self._validate_awg_repeat_count(repetitions, "child-sequence parent")
+        suffix_start = prefix_steps + repetitions * child_steps
+        suffix = steps[suffix_start:]
+        compact_body_steps = prefix_steps + 1 + len(suffix)
+        if compact_body_steps > self.awg_max_sequence_steps:
+            raise ValueError(
+                f"Compact AWG parent/body sequence has {compact_body_steps} steps, "
+                f"exceeding the configured AWG limit of {self.awg_max_sequence_steps}."
+            )
+        return steps[:prefix_steps], child, repetitions, suffix
+
+    def _infer_child_repetitions(
+        self, steps: list[AWGSequenceStep], prefix_steps: int, child: list[AWGSequenceStep]
+    ) -> int:
+        child_steps = len(child)
+        repetitions = 0
+        start = prefix_steps
+        while steps[start : start + child_steps] == child:
+            repetitions += 1
+            start += child_steps
+        if repetitions < 2:
+            raise ValueError(
+                "Could not infer awg_repeated_child repetitions: at least two "
+                "identical child occurrences are required."
+            )
+        return repetitions
 
     def run(self) -> None:
         logging.info("Sent run to MockSynchroniser".ljust(65, ".") + "[done]")
@@ -1263,6 +1627,15 @@ class PulseBlaster(Synchroniser):
         self.configure_pb()
 
     def load_sequence(self, ps_yaml_file: str = "sequence_0.yaml") -> None:
+        yaml_file = Path(ps_yaml_file)
+        if not yaml_file.is_absolute():
+            yaml_file = get_seq_dir() / yaml_file
+        with open(yaml_file, "r", encoding="utf-8") as file:
+            # PulseBlaster also consumes the expanded program directly. Keep
+            # Tek-only upload modes out of this path with a clear error.
+            _check_awg_sequence_mode_supported(
+                yaml.safe_load(file) or {}, "PulseBlaster", ("flat",)
+            )
         yaml_sequence_transpiler = PulseBlasterSequence(self.channel_mapping, ps_yaml_file)
         yaml_sequence_transpiler.parse_pulse_sequence_file()
         channel_bit_mask, pulse_duration_list = yaml_sequence_transpiler.compile()

--- a/qupyt/pulse_sequences/pulse_sequence_handler.py
+++ b/qupyt/pulse_sequences/pulse_sequence_handler.py
@@ -56,41 +56,7 @@ def write_user_ps(path: Path, params: Dict[str, Any]) -> Optional[Dict[str, Any]
     }
     user_ps = cast(UserPulseSeqProtocol, _load_module_from_path(path))
     dependent_parameters = user_ps.generate_sequence(params)
-    _copy_awg_sequence_options(params, previous_sequence_files)
     return dependent_parameters
-
-
-def _copy_awg_sequence_options(
-    params: Dict[str, Any], previous_sequence_files: Dict[Path, int]
-) -> None:
-    """Copy Tek-only upload options into generated sequence YAML files.
-
-    User pulse-sequence functions only receive params["pulse_sequence"] and write
-    sequence_*.yaml files. The Tek AWG backend reads those generated files, not
-    the outer measurement instruction file, so opt-in AWG upload settings have to
-    travel with the generated pulse sequence.
-    """
-
-    awg_options = {
-        key: params[key]
-        for key in ("awg_sequence_mode", "awg_repeated_child")
-        if key in params
-    }
-    if not awg_options:
-        return
-
-    generated_sequence_files = [
-        sequence_file
-        for sequence_file in get_seq_dir().glob("sequence_*.yaml")
-        if previous_sequence_files.get(sequence_file) != sequence_file.stat().st_mtime_ns
-    ]
-
-    for sequence_file in generated_sequence_files:
-        with open(sequence_file, "r", encoding="utf-8") as file:
-            sequence_yaml = yaml.safe_load(file)
-        sequence_yaml.update(awg_options)
-        with open(sequence_file, "w", encoding="utf-8") as file:
-            yaml.dump(sequence_yaml, file)
 
 
 def update_params_dict(

--- a/qupyt/pulse_sequences/pulse_sequence_handler.py
+++ b/qupyt/pulse_sequences/pulse_sequence_handler.py
@@ -7,6 +7,9 @@ import importlib.util
 from types import ModuleType
 from pathlib import Path
 from typing import Dict, Any, Optional, Protocol, cast
+import yaml
+
+from qupyt.set_up import get_seq_dir
 
 
 # pylint: disable=too-few-public-methods
@@ -46,9 +49,48 @@ def write_user_ps(path: Path, params: Dict[str, Any]) -> Optional[Dict[str, Any]
     Load user specified pulse sequence definition and
     execute it to generate the pulse sequence.
     """
+    sequence_dir = get_seq_dir()
+    previous_sequence_files = {
+        sequence_file: sequence_file.stat().st_mtime_ns
+        for sequence_file in sequence_dir.glob("sequence_*.yaml")
+    }
     user_ps = cast(UserPulseSeqProtocol, _load_module_from_path(path))
     dependent_parameters = user_ps.generate_sequence(params)
+    _copy_awg_sequence_options(params, previous_sequence_files)
     return dependent_parameters
+
+
+def _copy_awg_sequence_options(
+    params: Dict[str, Any], previous_sequence_files: Dict[Path, int]
+) -> None:
+    """Copy Tek-only upload options into generated sequence YAML files.
+
+    User pulse-sequence functions only receive params["pulse_sequence"] and write
+    sequence_*.yaml files. The Tek AWG backend reads those generated files, not
+    the outer measurement instruction file, so opt-in AWG upload settings have to
+    travel with the generated pulse sequence.
+    """
+
+    awg_options = {
+        key: params[key]
+        for key in ("awg_sequence_mode", "awg_repeated_child")
+        if key in params
+    }
+    if not awg_options:
+        return
+
+    generated_sequence_files = [
+        sequence_file
+        for sequence_file in get_seq_dir().glob("sequence_*.yaml")
+        if previous_sequence_files.get(sequence_file) != sequence_file.stat().st_mtime_ns
+    ]
+
+    for sequence_file in generated_sequence_files:
+        with open(sequence_file, "r", encoding="utf-8") as file:
+            sequence_yaml = yaml.safe_load(file)
+        sequence_yaml.update(awg_options)
+        with open(sequence_file, "w", encoding="utf-8") as file:
+            yaml.dump(sequence_yaml, file)
 
 
 def update_params_dict(


### PR DESCRIPTION
Fixes #50

### Description
This PR adds an opt-in repeated_child upload mode for Tektronix AWGs. The goal is to support long CASR repetitive-readout measurements that exceed the AWG sequencer step limit in flat mode.
The logical QuPyt pulse sequence remains fully expanded in the generated sequence_*.yaml. The compression happens only during TekAWG upload: the AWG backend validates the repeated region, creates a compact child sequence, and references it repeatedly from the parent sequence.
This was tested on a Tektronix AWG70001B.

### Motivation
CASR repetitive readout can generate very long AWG sequencing orders. In one tested case, the logical sequence contained:
```
Expanded logical steps: 24004
Prefix steps: 3
Child steps: 8
Child repetitions: 3000
Suffix steps: 1
``` 
The flat sequence exceeds the current default AWG sequence-step limit of `16384`. However, most of the sequence consists of one repeated CASR child cycle. Uploading this repeated cycle as a child sequence avoids exceeding the AWG sequencer step limit while preserving the logical timing structure.

### Main Changes
TekAWG repeated-child mode
Added support for:
```
awg_sequence_mode: repeated_child
awg_repeated_child:
  prefix_steps: 3
  child_steps: 8
  repetitions: 3000
```
The default remains:
`awg_sequence_mode: flat`
If no mode is specified, existing behavior is preserved.

### Validation before upload
The AWG backend validates the repeated-child configuration before constructing the hardware sequence. It checks:

- prefix_steps is non-negative
- child_steps is positive
- repetitions is positive
- the repeated region fits inside the expanded logical sequence
- all repeated child blocks match exactly
- TekAWG waveform names, repeat counts, and flags match
- repeat counts do not exceed the configured AWG limit
- compact parent/child sequence lengths do not exceed the configured AWG limit

This should catch configuration mistakes before they become unclear SCPI errors on the AWG.

### MockSynchroniser support
MockSynchroniser now accepts awg_sequence_mode: repeated_child as a dry-run validation mode.
It does not send SCPI commands or compress hardware waveforms. Instead, it checks the generated logical sequence at YAML level and verifies that the configured child region is actually repeated.
This makes it possible to test repeated-child logic without the real AWG.

### Unsupported synchronisers
PulseStreamer and PulseBlaster now reject repeated_child with a clear error, because they consume the expanded pulse program directly and do not implement Tek AWG parent/child sequencer compression.

### AWG limits
The default AWG limits are:
```
AWG_MAX_SEQUENCE_STEPS = 16_384
AWG_MAX_STEP_REPEAT = 1_048_576
```
These can optionally be overridden under synchroniser.config for other AWG models:
```
synchroniser:
  config:
    awg_max_sequence_steps: 16384
    awg_max_step_repeat: 1048576
```
If omitted, the defaults are used.

### AWG70000-series channel handling
The TekAWG backend now conservatively detects known AWG70000-series channel availability from `*IDN?`:
```
AWG70001 -> channel 1
AWG70002 -> channels 1 and 2
```
Unknown models are left unchanged instead of guessing.
This avoids sending invalid SOURCE2 commands to single-channel AWG70001 devices.

### AWG5202 guard
`repeated_child` is currently guarded for AWG5202. The implementation uses Tek AWG70000-series sequence asset/track SCPI and was tested on AWG70001B. AWG5202 may be similar, but should be verified with the programming manual or a hardware test before enabling this path.
Flat mode remains available.

### CASR pulse-sequence usage
For CASR repetitive readout, the repeated-child values should be calculated inside the pulse-sequence Python file, not manually entered in the instruction YAML.
Example pattern:
```
awg_repeated_child = {
    "prefix_steps": 3,
    "child_steps": len(cycle_order),
    "repetitions": n_meas,
}

casr_rr.pulse_sequence["awg_sequence_mode"] = params["awg_sequence_mode"]
casr_rr.pulse_sequence["awg_repeated_child"] = awg_repeated_child

casr_rr.write()

return{
'synchroniser': {
            'awg_sequence_mode': "repeated_child",
            'awg_repeated_child': awg_repeated_child
        },
}
```
This ensures that the generated `sequence_*.yaml` contains the calculated metadata used by TekAWG.
The AWG reads the generated `sequence_*.yaml`, not the original instruction YAML.
The saved measurement YAML can record the calculated mode metadata when the pulse-sequence file returns it under synchroniser.

### Tested / Verified

- Existing flat-mode measurements still work.
- Other Mock instruction files still work in flat mode.
- CASR repetitive readout uploads successfully in `repeated_child` mode on the tested Tektronix AWG70001B.
-  Verified on the AWG that the uploaded parent/child sequence structure is correct.
- The generated `sequence_*.yaml` contains the calculated `awg_sequence_mode` and `awg_repeated_child` metadata.
- The saved measurement YAML can record the calculated mode metadata if the pulse-sequence file returns it under synchroiser.
- Wrong child length or repetition settings raise clear validation errors.
- MockSynchroniser catches repeated-child structure errors without AWG hardware.
- PulseStreamer and PulseBlaster reject `repeated_child` with a clear message.
- Logs contain a compact one-line repeated-child summary.

Example successful AWG70001B repeated-child run:
```
Tek AWG sequence mode: repeated_child
Expanded logical steps: 24004
Prefix steps: 3
Child steps: 8
Child repetitions: 3000
Suffix steps: 1
Compact measurement steps: 5
Top-level steps: 6
Unique waveforms: 7
```

### Notes for reviewers
The repeated-child implementation was tested on Tektronix AWG70001B. It uses Tek AWG70000-series SCPI sequence asset/track commands. Other Tek AWGs, especially AWG5000/AWG5202-series devices, should be verified before enabling repeated_child.
The logical pulse sequence generation is intentionally left expanded. The compression happens only in the TekAWG upload layer.
The original instruction YAML does not need to contain awg_repeated_child for CASR if the pulse-sequence Python file calculates and writes it before casr_rr.write().


